### PR TITLE
Optimize bazel integration

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -93,6 +93,10 @@ const add /*: Add */ = async ({root, cwd, args, dev = false}) => {
       [yarn, 'workspace', meta.name, 'add', ...keys, ...flags],
       options
     );
+    // reload package.json affected by workspace add command
+    allDeps.find(item => item.dir === cwd).meta = JSON.parse(
+      await read(`${cwd}/package.json`)
+    );
     await spawn(node, [yarn, 'install'], options);
 
     const deps = /*:: await */ await getLocalDependencies({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.25",
+  "version": "0.0.0-standalone.26",
   "bin": {
     "barn": "bin/bootstrap.sh",
     "jazelle": "bin/bootstrap.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.26",
+  "version": "0.0.0-standalone.27",
   "bin": {
     "barn": "bin/bootstrap.sh",
     "jazelle": "bin/bootstrap.sh",

--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -69,14 +69,10 @@ if (out) {
 }
 
 function runCommands(command, args) {
-  if (command.startsWith('yarn ')) {
-    runCommand(command.substr(5), args);
-  } else {
-    if (command === 'run') {
-      command = args.shift();
-    }
-    runCommand(command, args);
+  if (command === 'run') {
+    command = args.shift();
   }
+  runCommand(command, args);
 }
 
 function runCommand(command, args = []) {
@@ -96,20 +92,18 @@ function runCommand(command, args = []) {
       }
     }
   } else {
-    if (command.includes('rpc-cli')) {
-      if (command.includes('${NODE}')) {
-        command = command
-          .split('${NODE}')
-          .join(`node -r ${join(rootDir, '.pnp.js')}`);
-      }
-      if (command.includes('${ROOT_DIR}')) {
-        command = command.split('${ROOT_DIR}').join(rootDir);
-      }
-      try {
-        exec(command, options);
-      } catch (e) {
-        process.exit(1);
-      }
+    if (command.includes('${NODE}')) {
+      command = command
+        .split('${NODE}')
+        .join(`node -r ${join(rootDir, '.pnp.js')}`);
+    }
+    if (command.includes('${ROOT_DIR}')) {
+      command = command.split('${ROOT_DIR}').join(rootDir);
+    }
+    try {
+      exec(command, options);
+    } catch (e) {
+      process.exit(1);
     }
   }
 }

--- a/rules/web-monorepo.bzl
+++ b/rules/web-monorepo.bzl
@@ -46,7 +46,7 @@ def _get_runfiles(ctx, outputs):
     export CWD=$(cd `dirname '{srcdir}'` && pwd);
     export NODE=$(cd `dirname '{node}'` && pwd)/$(basename '{node}');
     $NODE '{untar_script}' --runtime;
-    $NODE --max_old_space_size=65536 '{build}' "$CWD" "$(pwd)" '{command}' '' '{gen_srcs}' '' "$@"
+    $NODE --max_old_space_size=65536 '{build}' "$PWD" "$CWD" "$(pwd)" '{command}' '' '{gen_srcs}' '' "$@"
     """.format(
       node = ctx.files._node[0].path,
       srcdir = ctx.build_file_path,
@@ -80,7 +80,7 @@ def _web_binary_impl(ctx):
     export OUT=$(cd `dirname '{output}'` && pwd)/$(basename '{output}');
     export BAZEL_BIN_DIR=$(cd '{bindir}' && pwd);
     $NODE '{untar_script}';
-    $NODE --max_old_space_size=65536 '{build}' "$CWD" "$BAZEL_BIN_DIR" '{command}' '{dist}' '' "$OUT" $@;
+    $NODE --max_old_space_size=65536 '{build}' "$PWD" "$CWD" "$BAZEL_BIN_DIR" '{command}' '{dist}' '' "$OUT" $@;
     """.format(
       node = ctx.files._node[0].path,
       srcdir = ctx.build_file_path,

--- a/tests/fixtures/script/a/package.json
+++ b/tests/fixtures/script/a/package.json
@@ -2,7 +2,6 @@
   "name": "a",
   "version": "0.0.0",
   "scripts": {
-    "prefoo": "echo hi",
     "foo": "./echo.sh"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -826,7 +826,7 @@ async function testGenerateBazelBuildRules() {
   assert(code.includes('# name: a\n'));
   assert(code.includes('# path: a\n'));
   assert(code.includes('# label: //a:a\n'));
-  assert(code.includes('# dependencies: //b:b\n'));
+  assert(code.includes('# dependencies: //b:library\n'));
   const bBuild = `${tmp}/tmp/generate-bazel-build-rules/b/BUILD.bazel`;
   const cBuild = `${tmp}/tmp/generate-bazel-build-rules/c/BUILD.bazel`;
   const dBuild = `${tmp}/tmp/generate-bazel-build-rules/d/BUILD.bazel`;
@@ -868,7 +868,7 @@ async function testGenerateBazelBuildRulesUpdate() {
   const aBuild = `${tmp}/tmp/generate-bazel-build-rules-update/a/BUILD.bazel`;
   const data = await read(aBuild);
   assert(data.includes('custom_target_rule'));
-  assert(data.includes('//b:b'));
+  assert(data.includes('//b:library'));
   assert(!data.includes('//c:c'));
   assert(data.includes('//external:external'));
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -394,7 +394,6 @@ async function testScriptCommand() {
   });
 
   const lines = (await read(streamFile, 'utf8')).split('\n');
-  assert(lines.includes('hi'));
   assert(lines.includes('hello world'));
   assert(lines.includes('hello world foo'));
 }

--- a/utils/generate-bazel-build-rules.js
+++ b/utils/generate-bazel-build-rules.js
@@ -80,8 +80,10 @@ const generateBazelBuildRules /*: GenerateBazelBuildRules */ = async ({
           });
         items.forEach(item => {
           if (!dependencies.map(d => `"${d}"`).includes(item)) {
-            const [, path] = item.match(/\/\/(.+?):([^"]+)/) || [];
-            if (projects.includes(path)) {
+            const [, path, name] = item.match(/\/\/(.+?):([^"]+)/) || [];
+            // force include target allows for projects to be included as bazel deps even if they are not in package.json deps
+            // it is an edge case that should be avoided if at all possible
+            if (projects.includes(path) && name !== 'force-include') {
               code = removeCallArgItem(code, dependencySyncRule, 'deps', item);
             }
           }

--- a/utils/generate-bazel-build-rules.js
+++ b/utils/generate-bazel-build-rules.js
@@ -80,8 +80,8 @@ const generateBazelBuildRules /*: GenerateBazelBuildRules */ = async ({
           });
         items.forEach(item => {
           if (!dependencies.map(d => `"${d}"`).includes(item)) {
-            const [, path, name] = item.match(/\/\/(.+?):([^"]+)/) || [];
-            if (projects.includes(path) && basename(path) === name) {
+            const [, path] = item.match(/\/\/(.+?):([^"]+)/) || [];
+            if (projects.includes(path)) {
               code = removeCallArgItem(code, dependencySyncRule, 'deps', item);
             }
           }
@@ -95,10 +95,15 @@ const generateBazelBuildRules /*: GenerateBazelBuildRules */ = async ({
 const getDepLabels = (root, depMap, dependencies = {}) => {
   return Object.keys(dependencies)
     .map(name => {
-      const {dir} = depMap[name] || {};
+      const {dir, meta} = depMap[name] || {};
       if (dir) {
         const path = relative(root, dir);
-        const name = basename(path);
+        // use library target unless a build script is specified
+        // const name = meta.scripts && meta.scripts.build ? basename(path) : 'library';
+        let name = 'library';
+        if (meta.scripts && meta.scripts.build) {
+          name = basename(path);
+        }
         return `//${path}:${name}`;
       } else {
         return null;


### PR DESCRIPTION
This PR adds several optimizations to the bazel build process.

1. Update BUILD.bazel file generation to use library target whenever possible

The web_binary build target is significantly more expensive than the web_library target. Defaulting to the web_library target whenever possible significantly reduces bazel overhead.

2. Remove support for pre/post build package.json scripts

Yarn2 has also removed support for pre/post build package.json scripts as they can lead to confusing behavior. Removing this allows us to further reduce overhead in the web_binary target. (See https://yarnpkg.com/advanced/lifecycle-scripts/)

3. Add support for ${NODE} and ${ROOT_DIR} interpolations in web_binary build commands

In large monorepos, each call to yarn incurs overhead. Rather than trying to call yarn to find binary script locations, we can use string interpolation to directly call out workspace clis.
