### PR TITLE
Fix jz node handling of deps under yarn 2

### DIFF
--- a/commands/node.js
+++ b/commands/node.js
@@ -14,12 +14,13 @@ type NodeArgs = {
 }
 type Node = (NodeArgs) => Promise<void>
 */
-const runNode /*: Node */ = async ({root, cwd, args = [], stdio = 'inherit'}) => {
-  const params = [
-    '-r',
-    `${root}/.pnp.js`,
-    ...getPassThroughArgs(args),
-  ];
+const runNode /*: Node */ = async ({
+  root,
+  cwd,
+  args = [],
+  stdio = 'inherit',
+}) => {
+  const params = ['-r', `${root}/.pnp.js`, ...getPassThroughArgs(args)];
   await spawn(node, params, {env: process.env, cwd, stdio});
 };
 

--- a/commands/node.js
+++ b/commands/node.js
@@ -7,14 +7,19 @@ const {getPassThroughArgs} = require('../utils/parse-argv.js');
 import type {Stdio} from '../utils/node-helpers.js';
 
 type NodeArgs = {
+  root: string,
   cwd: string,
   args?: Array<string>,
   stdio?: Stdio,
 }
 type Node = (NodeArgs) => Promise<void>
 */
-const runNode /*: Node */ = async ({cwd, args = [], stdio = 'inherit'}) => {
-  const params = getPassThroughArgs(args);
+const runNode /*: Node */ = async ({root, cwd, args = [], stdio = 'inherit'}) => {
+  const params = [
+    '-r',
+    `${root}/.pnp.js`,
+    ...getPassThroughArgs(args),
+  ];
   await spawn(node, params, {env: process.env, cwd, stdio});
 };
 

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ const runCLI /*: RunCLI */ = async argv => {
 
         [args...]                  A space separated list of arguments
         --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => node({cwd, args: rest}),
+        async ({cwd}) => node({root: await rootOf(args), cwd, args: rest}),
       ],
       yarn: [
         `Runs a Yarn command


### PR DESCRIPTION
`jz node -p 'process.versions.pnp'` should not log `undefined`