### PR TITLE
Untar build outputs into sandbox build dir

### DIFF
--- a/rules/untar.js
+++ b/rules/untar.js
@@ -9,7 +9,7 @@ const {
   copyFileSync: cp,
 } = require('fs');
 const {execSync: exec} = require('child_process');
-const {dirname, resolve} = require('path');
+const {dirname, resolve, relative} = require('path');
 
 const root = process.cwd();
 const [runtime] = process.argv.slice(2);
@@ -19,6 +19,7 @@ const files = exec(`find . -name __jazelle__*.tgz`, options)
   .split('\n')
   .filter(Boolean);
 
+// TODO this file can be optimized with some parallelization
 files.map(file => {
   untarIntoSandbox(file);
   if (runtime) {
@@ -29,7 +30,17 @@ files.map(file => {
 function untarIntoSandbox(file) {
   const target = resolve(root, dirname(file));
   const untar = `tar xzf "${file}" -C "${target}"`;
-  exec(untar, {cwd: root});
+  // untar into the bazel-out directory
+  exec(untar, {cwd: root, stdio: 'inherit'});
+
+  // when in the build phase, we must also untar into the sandbox runtime dir
+  // if we only untar into the bazel-out/ dir, other builds steps will not be able to depend
+  // on the output of this build step.
+  if (!runtime) {
+    const relativeDir = relative(process.env.BAZEL_BIN_DIR, target);
+    const buildTargetDir = resolve(process.env.PWD, relativeDir);
+    exec(`tar xzf "${file}" -C "${buildTargetDir}"`);
+  }
 }
 
 function copyToSourceFolder(file) {

--- a/tests/fixtures/bazel-dependent-builds/a/package.json
+++ b/tests/fixtures/bazel-dependent-builds/a/package.json
@@ -6,7 +6,7 @@
     "c": "workspace:*"
   },
   "scripts": {
-    "build": "mkdir -p foo && echo 'console.log(require(\"b\") + require(\"c\"))' > foo/foo.js",
+    "build": "mkdir -p $CWD/foo && echo 'console.log(require(\"b\") + require(\"c\"))' > $CWD/foo/foo.js && ${NODE} $CWD/foo/foo.js",
     "start": "node foo/foo.js"
   }
 }

--- a/tests/fixtures/bazel-dependent-builds/b/package.json
+++ b/tests/fixtures/bazel-dependent-builds/b/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "main": "compiled/foo.js",
   "scripts": {
-    "build": "mkdir -p compiled && echo 'module.exports = 111' > compiled/foo.js"
+    "build": "mkdir -p $CWD/compiled && echo 'module.exports = 111' > $CWD/compiled/foo.js"
   }
 }

--- a/tests/fixtures/bazel-dependent-builds/c/package.json
+++ b/tests/fixtures/bazel-dependent-builds/c/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "main": "dist/foo.js",
   "scripts": {
-    "build": "mkdir -p dist && echo 'module.exports = 222' > dist/foo.js"
+    "build": "mkdir -p $CWD/dist && echo 'module.exports = 222' > $CWD/dist/foo.js"
   }
 }


### PR DESCRIPTION
During build phase, we must untar build outputs into sandbox build dir in addition to the bazel-out dir if we want to have the ability for a build target to depend on the output of another target.