### PR TITLE
Fix update-vendor script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "lint": "eslint .",
     "flow-check": "flow check",
     "test": "node tests/index.js",
-    "update-vendor": "yarn install --production=true --modules-folder vendor"
+    "preupdate-vendor": "mv vendor/.gitignore .vendor-gitignore",
+    "postupdate-vendor": "mv .vendor-gitignore vendor/.gitignore",
+    "update-vendor": "yarn install --prod --flat --frozen-lockfile --modules-folder=vendor"
   }
 }
 


### PR DESCRIPTION
- prevent yarn from clobbering `vendor/.gitignore`
- add `--flat` and `--frozen-lockfile`