### PR TITLE
Add yarn filtering to all relevant commands

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -8,13 +8,14 @@ export type BuildArgs = {
   root: string,
   cwd: string,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Build = (BuildArgs) => Promise<void>
 */
-const build /*: Build */ = async ({root, cwd, stdio = 'inherit'}) => {
+const build /*: Build */ = async ({root, cwd, stdio, verbose = false}) => {
   await assertProjectDir({dir: cwd});
 
-  await executeProjectCommand({root, cwd, command: 'build', stdio});
+  await executeProjectCommand({root, cwd, command: 'build', stdio, verbose});
 };
 
 module.exports = {build};

--- a/commands/ci.js
+++ b/commands/ci.js
@@ -5,11 +5,12 @@ const {install} = require('./install.js');
 export type CiArgs = {
   root: string,
   cwd: string,
+  verbose?: boolean,
 }
 export type Ci = (CiArgs) => Promise<void>
 */
-const ci /*: Ci */ = async ({root, cwd}) => {
-  await install({root, cwd, frozenLockfile: true, conservative: true});
+const ci /*: Ci */ = async ({root, cwd, verbose = false}) => {
+  await install({root, cwd, frozenLockfile: true, conservative: true, verbose});
 };
 
 module.exports = {ci};

--- a/commands/dev.js
+++ b/commands/dev.js
@@ -10,10 +10,11 @@ export type DevArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Dev = (DevArgs) => Promise<void>
 */
-const dev /*: Dev */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const dev /*: Dev */ = async ({root, cwd, args, stdio, verbose = false}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
@@ -23,6 +24,7 @@ const dev /*: Dev */ = async ({root, cwd, args, stdio = 'inherit'}) => {
     command: 'dev',
     args: params,
     stdio,
+    verbose,
   });
 };
 

--- a/commands/exec.js
+++ b/commands/exec.js
@@ -10,14 +10,21 @@ export type ExecArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Exec = (ExecArgs) => Promise<void>
 */
-const exec /*: Exec */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const exec /*: Exec */ = async ({root, cwd, args, stdio, verbose = false}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
-  await executeProjectCommand({root, cwd, command: 'exec', args: params});
+  await executeProjectCommand({
+    root,
+    cwd,
+    command: 'exec',
+    args: params,
+    verbose,
+  });
 };
 
 module.exports = {exec};

--- a/commands/flow.js
+++ b/commands/flow.js
@@ -10,10 +10,11 @@ export type FlowArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Flow = (FlowArgs) => Promise<void>
 */
-const flow /*: Flow */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const flow /*: Flow */ = async ({root, cwd, args, stdio, verbose = false}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
@@ -23,6 +24,7 @@ const flow /*: Flow */ = async ({root, cwd, args, stdio = 'inherit'}) => {
     command: 'flow',
     args: params,
     stdio,
+    verbose,
   });
 };
 

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -10,10 +10,11 @@ export type LintArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Lint = (LintArgs) => Promise<void>
 */
-const lint /*: Lint */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const lint /*: Lint */ = async ({root, cwd, args, stdio, verbose = false}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
@@ -23,6 +24,7 @@ const lint /*: Lint */ = async ({root, cwd, args, stdio = 'inherit'}) => {
     command: 'lint',
     args: params,
     stdio,
+    verbose,
   });
 };
 

--- a/commands/script.js
+++ b/commands/script.js
@@ -10,10 +10,17 @@ type ScriptArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 };
 type Script = (ScriptArgs) => Promise<void>;
 */
-const script /*: Script */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const script /*: Script */ = async ({
+  root,
+  cwd,
+  args,
+  stdio,
+  verbose = false,
+}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
@@ -23,6 +30,7 @@ const script /*: Script */ = async ({root, cwd, args, stdio = 'inherit'}) => {
     command: 'script',
     args: params,
     stdio,
+    verbose,
   });
 };
 

--- a/commands/start.js
+++ b/commands/start.js
@@ -10,10 +10,17 @@ export type StartArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type Start = (StartArgs) => Promise<void>
 */
-const start /*: Start */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const start /*: Start */ = async ({
+  root,
+  cwd,
+  args,
+  stdio,
+  verbose = false,
+}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
@@ -23,6 +30,7 @@ const start /*: Start */ = async ({root, cwd, args, stdio = 'inherit'}) => {
     command: 'start',
     args: params,
     stdio,
+    verbose,
   });
 };
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -4,17 +4,18 @@ const {getManifest} = require('../utils/get-manifest.js');
 const {findLocalDependency} = require('../utils/find-local-dependency.js');
 const {read, write} = require('../utils/node-helpers.js');
 const {sortPackageJson} = require('../utils/sort-package-json.js');
-const {spawn} = require('../utils/node-helpers.js');
+const {spawnFiltered} = require('../utils/spawn-filtered.js');
 const {node, yarn} = require('../utils/binary-paths.js');
 
 /*::
 export type UpgradeArgs = {
   root: string,
   args: Array<string>,
+  verbose?: boolean,
 };
 export type Upgrade = (UpgradeArgs) => Promise<void>;
 */
-const upgrade /*: Upgrade */ = async ({root, args}) => {
+const upgrade /*: Upgrade */ = async ({root, args, verbose = false}) => {
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 
@@ -52,9 +53,9 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
     const deps = externals.map(({name, range}) => {
       return name + (range ? `@${range}` : '');
     });
-    await spawn(node, [yarn, 'up', '-C', ...deps], {
-      cwd: root,
-      stdio: 'inherit',
+    await spawnFiltered(node, [yarn, 'up', '-C', ...deps], {
+      spawnOpts: {cwd: root},
+      verbose,
     });
   }
 };

--- a/commands/yarn.js
+++ b/commands/yarn.js
@@ -1,7 +1,7 @@
 // @flow
-const {spawn} = require('../utils/node-helpers.js');
-const {node, yarn} = require('../utils/binary-paths.js');
 const {getPassThroughArgs} = require('../utils/parse-argv.js');
+const {spawnFiltered} = require('../utils/spawn-filtered.js');
+const {node, yarn} = require('../utils/binary-paths.js');
 
 /*::
 import type {Stdio} from '../utils/node-helpers.js';
@@ -10,12 +10,21 @@ type YarnArgs = {
   cwd: string,
   args?: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 type Yarn = (YarnArgs) => Promise<void>
 */
-const runYarn /*: Yarn */ = async ({cwd, args = [], stdio = 'inherit'}) => {
+const runYarn /*: Yarn */ = async ({
+  cwd,
+  args = [],
+  stdio,
+  verbose = false,
+}) => {
   const params = [yarn, ...getPassThroughArgs(args)];
-  await spawn(node, params, {env: process.env, cwd, stdio});
+  await spawnFiltered(node, params, {
+    spawnOpts: {env: process.env, cwd, stdio},
+    verbose,
+  });
 };
 
 module.exports = {yarn: runYarn};

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const runCLI /*: RunCLI */ = async argv => {
         --cwd [cwd]                Project directory to use
         --skipPreinstall           Skip the preinstall hook
         --skipPostinstall          Skip the postinstall hook
-        --verbose`,
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
         async ({cwd, skipPreinstall, skipPostinstall, verbose}) =>
           install({
             root: await rootOf(args),
@@ -95,21 +95,25 @@ const runCLI /*: RunCLI */ = async argv => {
       ci: [
         `Install all dependencies for a project without modifying source files
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => ci({root: await rootOf(args), cwd}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          ci({root: await rootOf(args), cwd, verbose: Boolean(verbose)}),
       ],
       add: [
         `Install a package and any packages that it depends on
 
         [deps...]                  Package(s) to add at a specific version. ie., foo@1.2.3
         --dev                      Whether to install as devDependency
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd, dev}) =>
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, dev, verbose = false}) =>
           add({
             root: await rootOf(args),
             cwd,
             args: rest.filter(arg => arg != '--dev'), // if dev is passed before name, resolve to correct value
             dev: Boolean(dev), // FIXME all args can technically be boolean, but we don't want Flow complaining about it everywhere
+            verbose: Boolean(verbose),
           }),
       ],
       remove: [
@@ -123,8 +127,14 @@ const runCLI /*: RunCLI */ = async argv => {
       upgrade: [
         `Upgrade a package version across all projects
 
-        [args...]                     Packages to upgrade and optionally their version ranges. e.g., foo@^1.2.3 bar@^1.2.3`,
-        async () => upgrade({root: await rootOf(args), args: rest}),
+        [args...]                  Packages to upgrade and optionally their version ranges. e.g., foo@^1.2.3 bar@^1.2.3
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({verbose}) =>
+          upgrade({
+            root: await rootOf(args),
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       purge: [
         `Remove generated files (i.e. node_modules folders and bazel output files)`,
@@ -196,38 +206,75 @@ const runCLI /*: RunCLI */ = async argv => {
       build: [
         `Build a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => build({root: await rootOf(args), cwd}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          build({root: await rootOf(args), cwd, verbose: Boolean(verbose)}),
       ],
       dev: [
         `Run a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => dev({root: await rootOf(args), cwd, args: rest}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          dev({
+            root: await rootOf(args),
+            cwd,
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       test: [
         `Test a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => test({root: await rootOf(args), cwd, args: rest}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          test({
+            root: await rootOf(args),
+            cwd,
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       lint: [
         `Lint a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => lint({root: await rootOf(args), cwd, args: rest}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          lint({
+            root: await rootOf(args),
+            cwd,
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       flow: [
         `Typecheck a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => flow({root: await rootOf(args), cwd, args: rest}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          flow({
+            root: await rootOf(args),
+            cwd,
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       start: [
         `Run a project
 
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) => start({root: await rootOf(args), cwd, args: rest}),
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
+          start({
+            root: await rootOf(args),
+            cwd,
+            args: rest,
+            verbose: Boolean(verbose),
+          }),
       ],
       'bin-path': [
         `Print the local path of a binary
@@ -294,12 +341,14 @@ const runCLI /*: RunCLI */ = async argv => {
         `Runs a npm script
 
         [args...]                  A space separated list of arguments
-        --cwd [cwd]                Project directory to use`,
-        async ({cwd}) =>
+        --cwd [cwd]                Project directory to use
+        --verbose                  Show noisy stdout/stderr that's normally filtered`,
+        async ({cwd, verbose}) =>
           script({
             root: await rootOf(args),
             cwd,
             args: rest,
+            verbose: Boolean(verbose),
           }),
       ],
     },

--- a/utils/execute-project-command.js
+++ b/utils/execute-project-command.js
@@ -12,6 +12,7 @@ export type ExecuteProjectCommandArgs = {
   command: string,
   args?: Array<string>,
   stdio?: Stdio,
+  verbose?: boolean,
 }
 export type ExecuteProjectCommand = (ExecuteProjectCommandArgs) => Promise<void>
 */
@@ -20,28 +21,36 @@ const executeProjectCommand /*: ExecuteProjectCommand */ = async ({
   cwd,
   command,
   args = [],
-  stdio = 'inherit',
+  stdio,
+  verbose = false,
 }) => {
   const {projects, workspace} = await getManifest({root});
   if (workspace === 'sandbox') {
     switch (command) {
       case 'dev':
-        return bazel.dev({root, cwd, args});
+        return bazel.dev({root, cwd, args, verbose});
       case 'test':
-        return bazel.test({root, cwd, args, stdio});
+        return bazel.test({root, cwd, args, stdio, verbose});
       case 'lint':
-        return bazel.lint({root, cwd, args, stdio});
+        return bazel.lint({root, cwd, args, stdio, verbose});
       case 'flow':
-        return bazel.flow({root, cwd, args, stdio});
+        return bazel.flow({root, cwd, args, stdio, verbose});
       case 'build':
-        return bazel.build({root, cwd});
+        return bazel.build({root, cwd, verbose});
       case 'start':
-        return bazel.start({root, cwd, args});
+        return bazel.start({root, cwd, args, verbose});
       case 'exec':
-        return bazel.exec({root, cwd, args, stdio});
+        return bazel.exec({root, cwd, args, stdio, verbose});
       case 'script': {
         const [cmd, ...rest] = args;
-        return bazel.script({root, cwd, command: cmd, args: rest, stdio});
+        return bazel.script({
+          root,
+          cwd,
+          command: cmd,
+          args: rest,
+          stdio,
+          verbose,
+        });
       }
     }
   } else {

--- a/utils/spawn-filtered.js
+++ b/utils/spawn-filtered.js
@@ -1,0 +1,46 @@
+// @flow
+
+const {spawn} = require('./node-helpers');
+
+/*::
+import type {SpawnOptions} from './node-helpers.js';
+
+export type SpawnFilteredOptions = {
+  spawnOpts?: SpawnOptions,
+  verbose: boolean,
+};
+
+export type SpawnFiltered = (string, Array<string>, SpawnFilteredOptions) => Promise<void>;
+*/
+
+/**
+ * A special utility for spawning yarn processes which filters
+ * out noisy stdout/stderr
+ */
+const spawnFiltered /*: SpawnFiltered */ = async (cmd, args, opts) => {
+  const spawnOpts = opts.spawnOpts || {};
+
+  if (opts.verbose) {
+    spawnOpts.stdio = 'inherit';
+  } else if (!spawnOpts.stdio) {
+    spawnOpts.env = {
+      ...spawnOpts.env,
+      // FORCE_COLOR is for the chalk package used by yarn
+      FORCE_COLOR: '1',
+    };
+    spawnOpts.filterOutput = filterOutput;
+  }
+
+  return spawn(cmd, args, spawnOpts);
+};
+
+function filterOutput(line, type) {
+  return (
+    !/doesn't provide .+ requested by /.test(line) &&
+    !/provides .+ requested by /.test(line) &&
+    !/can't be found in the cache and will be fetched/.test(line) &&
+    !/\[MODULE_NOT_FOUND\]/.test(line)
+  );
+}
+
+module.exports.spawnFiltered = spawnFiltered;


### PR DESCRIPTION
This moves the logic we've been using in `jz install` to filter noisy yarn v2 output into a `spawnFiltered` utility. This utility is then used in all places that could spawn yarn v2 commands (including some bazel commands, e.g. `jz dev`).

This also adds an additional filter to filter `[MODULE_NOT_FOUND]` logs