### PR TITLE
Ensure gen_src only applies within the project's folder rather than repo-wide

### DIFF
--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -114,7 +114,7 @@ function generateSources({root, main, regexes}) {
   const relSandbox = relative(root, dir);
   const real = realDir.replace(`/${relSandbox}`, '');
   for (const regex of regexes) {
-    const sandboxed = find({root, regex: new RegExp(regex)});
+    const sandboxed = find({root: main, regex: new RegExp(regex)});
     for (const item of sandboxed) {
       const rel = relative(root, item);
       const sandboxedPath = `${root}/${rel}`;


### PR DESCRIPTION
If gen_src applies repo-wide, then the logic to delete extraneous files will pick up anything within folders that happen to have a matching name, e.g.

```
- root
  - my-project
    - BUILD.bazel
      - gen_src = ["artifacts"]
    - artifacts
      - foo.txt <- should be regenerated
  - artifacts
    - bar.txt <- should NOT be deleted 
```