### PR TITLE
Performance improvements for `jz outdated` command

### DIFF
--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -11,13 +11,88 @@ type OutdatedArgs = {
   logger?: (...data: Array<mixed>) => void | mixed
 };
 type Outdated = (OutdatedArgs) => Promise<void>
+
+type Result = {
+  name: string,
+  range: Array<string>,
+  latest: string,
+};
 */
+
+/**
+ * Partitions the provided array into an array-of-arrays with inner arrays
+ * of size chunkSize or smaller.
+ */
+const partition /*: <T: any>(Array<T>, number) => Array<Array<T>> */ = (
+  arr,
+  chunkSize
+) => {
+  return [].concat.apply(
+    [],
+    arr.map(function (elem, i) {
+      return i % chunkSize ? [] : [arr.slice(i, i + chunkSize)];
+    })
+  );
+};
+
+/**
+ * An async implementation that mirrors Array.prototype.forEach.
+ */
+const forEachAsync /*: <TSrc: any, TDest: any>(Array<TSrc>, TSrc => Promise<TDest>) => Promise<void> */ = async (
+  arr,
+  callback
+) => {
+  await Promise.all(arr.map(callback));
+};
+
+/**
+ * Fetches metadata for the provided packages via the 'npm info' command.
+ */
+const fetchInfo = async (
+  packages /*: Array<string> */,
+  batchSize = 10
+) /*: Promise<{ [string]: {[string]: mixed} }> */ => {
+  let queries = {};
+  const setLatest = data => {
+    try {
+      const parsed /*: { [string]: string } */ = JSON.parse(data);
+      queries[parsed.name] = parsed;
+    } catch (e) {
+      /*do nothing*/
+    }
+  };
+
+  await forEachAsync(partition(packages, batchSize), async group => {
+    const flags = '-f version --json';
+    const cmd = `${node} ${yarn} npm info "${group.join(`" "`)}" ${flags}`;
+    try {
+      const result = await exec(cmd, {maxBuffer: 5 * 1024 * 1024});
+      result
+        .trim()
+        .split('\n')
+        .forEach(data => {
+          setLatest(data);
+        });
+    } catch (e) {
+      /* a single failure can cause the exec call to throw an exception.  In those
+       * cases, attempt to fetch for each package individually and only skip the
+       * failing package */
+      if (batchSize > 1) {
+        Object.assign(queries, await fetchInfo(group, 1));
+      }
+    }
+  });
+  return queries;
+};
 
 const outdated /*: Outdated */ = async ({root, logger = console.log}) => {
   const {projects} = await getManifest({root});
   const locals = await getAllDependencies({root, projects});
-  const map = {};
+  const getLocal = name => locals.find(local => local.meta.name === name);
+  const map /*: {[string]: Set<string>} */ = {};
   const types = ['dependencies', 'devDependencies'];
+  const results /*: Array<Result> */ = [];
+
   for (const local of locals) {
     for (const type of types) {
       if (local.meta[type]) {
@@ -28,37 +103,43 @@ const outdated /*: Outdated */ = async ({root, logger = console.log}) => {
       }
     }
   }
-  // report local discrepancies
+
+  // handle local discrepancies
   for (const name in map) {
-    const local = locals.find(local => local.meta.name === name);
+    const local = getLocal(name);
     if (local) {
       const {version} = local.meta;
-      for (const range of map[name]) {
-        if (version !== range) logger(name, range, version);
+      const outOfDate = [...map[name]].filter(
+        (consumed /*: string */) => consumed !== version
+      );
+      if (outOfDate.length > 0) {
+        results.push({name, range: outOfDate, latest: version});
       }
     }
   }
-  // then report registry discrepancies
-  for (const name in map) {
-    const local = locals.find(local => local.meta.name === name);
-    if (!local) {
-      const query = `${node} ${yarn} npm info ${name} -f version --json 2>/dev/null`;
-      let latest;
-      try {
-        const meta = JSON.parse(await exec(query));
-        latest = meta.version;
-      } catch (e) {
-        continue;
-      }
-      if (latest) {
-        for (const range of map[name]) {
-          if (!validRange(range) || !validRange(latest)) {
-            continue;
-          }
-          if (gt(latest, minVersion(range))) logger(name, range, latest);
+
+  // handle registry discrepancies
+  const info = await fetchInfo(
+    Object.keys(map).filter((pckg /*: string */) => !getLocal(pckg))
+  );
+
+  for (const name in info) {
+    const latest = info[name].version;
+    if (latest && typeof latest === 'string') {
+      for (const range of map[name]) {
+        if (!validRange(range) || !validRange(latest)) {
+          continue;
+        }
+        if (gt(latest, minVersion(range))) {
+          results.push({name, range: [range], latest});
         }
       }
     }
+  }
+
+  // report discrepancies
+  for (const {name, range, latest} of results) {
+    logger(name, range[0], latest);
   }
 };
 

--- a/tests/fixtures/outdated/a/package.json
+++ b/tests/fixtures/outdated/a/package.json
@@ -1,6 +1,7 @@
 {
   "name": "a",
   "dependencies": {
-    "only-version-one-zero-zero": "0.1.0"
+    "only-version-one-zero-zero": "0.1.0",
+    "@alexmsmithca/does-not-exist": "1.0.0"
   }
 }


### PR DESCRIPTION
Refactors the logic from Brady Thornton's [D5420795](https://code.uberinternal.com/D5420795) (internal) into the `jz outdated` command.

In particular, it adds batching of multiple packages into a single `npm info` call and runs all of these requests in parallel.

---

Before:

```
jz outdated  2377.82s user 253.81s system 54% cpu 1:21:02.60 total
```

After:

```
jz outdated  597.43s user 66.25s system 720% cpu 1:32.11 total
```

Roughly a 2-order of magnitude improvement in performance.

 