### PR TITLE
Add --json option to `jazelle outdated` command

### DIFF
--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -14,10 +14,11 @@ type OutdatedArgs = {
 };
 type Outdated = (OutdatedArgs) => Promise<void>
 
+type Version = string;
 type Result = {
-  name: string,
-  range: Array<string>,
-  latest: string,
+  packageName: string,
+  installed: Array<Version>,
+  latest: Version,
 };
 */
 
@@ -120,7 +121,11 @@ const outdated /*: Outdated */ = async ({
         (consumed /*: string */) => consumed !== version
       );
       if (outOfDate.length > 0) {
-        results.push({name, range: outOfDate, latest: version});
+        results.push({
+          packageName: name,
+          installed: outOfDate,
+          latest: version,
+        });
       }
     }
   }
@@ -140,18 +145,30 @@ const outdated /*: Outdated */ = async ({
         }
       }
       if (outdated.length > 0) {
-        results.push({name, range: outdated, latest});
+        results.push({packageName: name, installed: outdated, latest});
       }
     }
   }
 
   // report discrepancies
-  for (const {name, range, latest} of results) {
+  for (const result of results) {
+    const formatted = [];
     if (dedup) {
-      logger(name, range.join(' '), latest);
+      formatted.push(result);
     } else {
-      range.forEach(version => logger(name, version, latest));
+      result.installed.forEach(version =>
+        formatted.push({
+          ...result,
+          installed: [version],
+        })
+      );
     }
+
+    formatted.forEach(entry =>
+      json
+        ? logger(JSON.stringify(entry))
+        : logger(entry.packageName, entry.installed.join(' '), entry.latest)
+    );
   }
 };
 

--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -164,11 +164,15 @@ const outdated /*: Outdated */ = async ({
       );
     }
 
-    formatted.forEach(entry =>
+    if (json) logger('[');
+    formatted.forEach((entry, i) =>
       json
-        ? logger(JSON.stringify(entry))
+        ? logger(
+            JSON.stringify(entry) + (i !== formatted.length - 1 ? ',' : '')
+          )
         : logger(entry.packageName, entry.installed.join(' '), entry.latest)
     );
+    if (json) logger(']');
   }
 };
 

--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -8,6 +8,8 @@ const {minVersion, gt, validRange} = require('../utils/cached-semver');
 /*::
 type OutdatedArgs = {
   root: string,
+  json?: boolean,
+  dedup?: boolean,
   logger?: (...data: Array<mixed>) => void | mixed
 };
 type Outdated = (OutdatedArgs) => Promise<void>
@@ -85,7 +87,12 @@ const fetchInfo = async (
   return queries;
 };
 
-const outdated /*: Outdated */ = async ({root, logger = console.log}) => {
+const outdated /*: Outdated */ = async ({
+  root,
+  json = false,
+  dedup = false,
+  logger = console.log,
+}) => {
   const {projects} = await getManifest({root});
   const locals = await getAllDependencies({root, projects});
   const getLocal = name => locals.find(local => local.meta.name === name);
@@ -125,21 +132,26 @@ const outdated /*: Outdated */ = async ({root, logger = console.log}) => {
 
   for (const name in info) {
     const latest = info[name].version;
-    if (latest && typeof latest === 'string') {
-      for (const range of map[name]) {
-        if (!validRange(range) || !validRange(latest)) {
-          continue;
+    if (latest && typeof latest === 'string' && validRange(latest)) {
+      const outdated = [];
+      for (const version of map[name]) {
+        if (validRange(version) && gt(latest, minVersion(version))) {
+          outdated.push(version);
         }
-        if (gt(latest, minVersion(range))) {
-          results.push({name, range: [range], latest});
-        }
+      }
+      if (outdated.length > 0) {
+        results.push({name, range: outdated, latest});
       }
     }
   }
 
   // report discrepancies
   for (const {name, range, latest} of results) {
-    logger(name, range[0], latest);
+    if (dedup) {
+      logger(name, range.join(' '), latest);
+    } else {
+      range.forEach(version => logger(name, version, latest));
+    }
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -143,8 +143,16 @@ const runCLI /*: RunCLI */ = async argv => {
           }),
       ],
       outdated: [
-        `Displays deps whose version is behind the latest version`,
-        async () => outdated({root: await rootOf(args)}),
+        `Displays deps whose version is behind the latest version
+
+        --json                     Whether to print as JSON (e.g. for piping to jq)
+        --dedup                    De-duplicates results by combining used versions into a single result`,
+        async (json, dedup) =>
+          outdated({
+            root: await rootOf(args),
+            json: Boolean(json),
+            dedup: Boolean(dedup),
+          }),
       ],
       resolutions: [
         `Displays list of yarn resolutions`,

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ const runCLI /*: RunCLI */ = async argv => {
 
         --json                     Whether to print as JSON (e.g. for piping to jq)
         --dedup                    De-duplicates results by combining used versions into a single result`,
-        async (json, dedup) =>
+        async ({json, dedup}) =>
           outdated({
             root: await rootOf(args),
             json: Boolean(json),

--- a/tests/fixtures/outdated/b/package.json
+++ b/tests/fixtures/outdated/b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "a",
+  "dependencies": {
+    "only-version-one-zero-zero": "0.2.0"
+  }
+}

--- a/tests/fixtures/outdated/manifest.json
+++ b/tests/fixtures/outdated/manifest.json
@@ -1,3 +1,3 @@
 {
-  "projects": ["a"]
+  "projects": ["a", "b"]
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -83,7 +83,6 @@ async function t(test) {
 async function runTests() {
   await exec(`rm -rf ${tmp}/tmp`);
   await exec(`mkdir -p ${tmp}/tmp`);
-
   await Promise.all([
     t(testRunCLI),
     t(testInit),
@@ -2058,17 +2057,18 @@ async function testOutdated() {
 
   // Test --json option w/ --dedup
   await outdated({root, logger, json: true, dedup: true});
-  assert.equal(data.length, 1);
   let parsed /*: ?{[string]: string} */;
   try {
-    parsed = JSON.parse(data[0]);
+    parsed = JSON.parse(data.join(''));
   } catch (e) {
     // $FlowFixMe
-    assert.fail(`Unable to call JSON.parse on data: ${data}`);
+    assert.fail(`Unable to call JSON.parse on data: ${data.join('')}`);
   }
-  assert.deepEqual(parsed, {
-    packageName: 'only-version-one-zero-zero',
-    installed: ['0.1.0', '0.2.0'],
-    latest: '1.0.0',
-  });
+  assert.deepEqual(parsed, [
+    {
+      packageName: 'only-version-one-zero-zero',
+      installed: ['0.1.0', '0.2.0'],
+      latest: '1.0.0',
+    },
+  ]);
 }


### PR DESCRIPTION
Similar to the output from [D5420795](https://code.uberinternal.com/D5420795), with the exception of the `latestIsGreater` field.

Example output:

```
{"packageName":"@babel/plugin-transform-flow-strip-types","installed":["7.10.4"],"latest":"7.12.13"}
{"packageName":"@babel/preset-env","installed":["7.12.1"],"latest":"7.12.16"}
{"packageName":"@babel/preset-react","installed":["7.12.1"],"latest":"7.12.13"}
{"packageName":"graphql-parse-resolve-info","installed":["4.7.0"],"latest":"4.11.0"}
{"packageName":"@turf/helpers","installed":["4.7.3"],"latest":"6.3.0"}
{"packageName":"eslint-import-resolver-node","installed":["0.3.3"],"latest":"0.3.4"}
{"packageName":"nodemon","installed":["2.0.4"],"latest":"2.0.7"}
{"packageName":"fusion-plugin-react-redux","installed":["2.1.3"],"latest":"2.2.3"}
{"packageName":"fusion-plugin-redux-action-emitter-enhancer","installed":["3.1.6"],"latest":"3.1.8"}
...
```