### PR TITLE
Update references of .pnp.js to .pnp.cjs

### DIFF
--- a/commands/node.js
+++ b/commands/node.js
@@ -20,7 +20,7 @@ const runNode /*: Node */ = async ({
   args = [],
   stdio = 'inherit',
 }) => {
-  const params = ['-r', `${root}/.pnp.js`, ...getPassThroughArgs(args)];
+  const params = ['-r', `${root}/.pnp.cjs`, ...getPassThroughArgs(args)];
   await spawn(node, params, {env: process.env, cwd, stdio});
 };
 

--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -95,7 +95,7 @@ function runCommand(command, args = []) {
     if (command.includes('${NODE}')) {
       command = command
         .split('${NODE}')
-        .join(`${node} -r ${join(rootDir, '.pnp.js')}`);
+        .join(`${node} -r ${join(rootDir, '.pnp.cjs')}`);
     }
     if (command.includes('${ROOT_DIR}')) {
       command = command.split('${ROOT_DIR}').join(rootDir);

--- a/templates/scaffold/BUILD.bazel
+++ b/templates/scaffold/BUILD.bazel
@@ -7,7 +7,7 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 filegroup(
     name = "yarn",
     srcs = [
-        ".pnp.js",
+        ".pnp.cjs",
         ".yarn",
         "package.json",
         "yarn.lock",

--- a/tests/fixtures/bazel-dependent-builds/BUILD.bazel
+++ b/tests/fixtures/bazel-dependent-builds/BUILD.bazel
@@ -6,5 +6,5 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 
 filegroup(
   name = "yarn",
-  srcs = [".pnp.js", "package.json", "yarn.lock"],
+  srcs = [".pnp.cjs", "package.json", "yarn.lock"],
 )

--- a/tests/fixtures/bazel-dependent-failure/BUILD.bazel
+++ b/tests/fixtures/bazel-dependent-failure/BUILD.bazel
@@ -6,5 +6,5 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 
 filegroup(
   name = "yarn",
-  srcs = [".pnp.js", "package.json", "yarn.lock"],
+  srcs = [".pnp.cjs", "package.json", "yarn.lock"],
 )

--- a/tests/fixtures/bazel-rules/BUILD.bazel
+++ b/tests/fixtures/bazel-rules/BUILD.bazel
@@ -6,5 +6,5 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 
 filegroup(
   name = "yarn",
-  srcs = [".pnp.js", "package.json", "yarn.lock"],
+  srcs = [".pnp.cjs", "package.json", "yarn.lock"],
 )

--- a/tests/fixtures/bin/BUILD.bazel
+++ b/tests/fixtures/bin/BUILD.bazel
@@ -6,5 +6,5 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 
 filegroup(
     name = "yarn",
-    srcs = [".pnp.js", "package.json", "yarn.lock"],
+    srcs = [".pnp.cjs", "package.json", "yarn.lock"],
 )

--- a/tests/fixtures/script/BUILD.bazel
+++ b/tests/fixtures/script/BUILD.bazel
@@ -6,5 +6,5 @@ jazelle(name = "jazelle", manifest = "manifest.json")
 
 filegroup(
   name = "yarn",
-  srcs = [".pnp.js", "package.json", "yarn.lock"],
+  srcs = [".pnp.cjs", "package.json", "yarn.lock"],
 )


### PR DESCRIPTION
Current version of yarn berry uses .pnp.cjs instead of .pnp.js. This updates all references