### PR TITLE
Do not sort package.json files on bump or upgrade commands

### DIFF
--- a/commands/bump.js
+++ b/commands/bump.js
@@ -6,7 +6,6 @@ const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
 const {exec, write} = require('../utils/node-helpers.js');
 const {node, yarn} = require('../utils/binary-paths.js');
 const {upgrade} = require('./upgrade.js');
-const {sortPackageJson} = require('../utils/sort-package-json');
 
 /*::
 type BumpArgs = {

--- a/commands/bump.js
+++ b/commands/bump.js
@@ -59,7 +59,7 @@ const bump /*: Bump */ = async ({
         console.log(
           `${dep.meta.name} is a dependency of ${cwd} but it is marked as private, thus cannot be published.`
         );
-      await write(`${dep.dir}/package.json`, dep.meta, 'utf8');
+      await write(`${dep.dir}/package.json`, JSON.stringify(dep.meta, null, 2), 'utf8');
 
       await upgrade({
         root,

--- a/commands/bump.js
+++ b/commands/bump.js
@@ -59,7 +59,11 @@ const bump /*: Bump */ = async ({
         console.log(
           `${dep.meta.name} is a dependency of ${cwd} but it is marked as private, thus cannot be published.`
         );
-      await write(`${dep.dir}/package.json`, JSON.stringify(dep.meta, null, 2), 'utf8');
+      await write(
+        `${dep.dir}/package.json`,
+        JSON.stringify(dep.meta, null, 2),
+        'utf8'
+      );
 
       await upgrade({
         root,

--- a/commands/bump.js
+++ b/commands/bump.js
@@ -60,7 +60,7 @@ const bump /*: Bump */ = async ({
         console.log(
           `${dep.meta.name} is a dependency of ${cwd} but it is marked as private, thus cannot be published.`
         );
-      await write(`${dep.dir}/package.json`, sortPackageJson(dep.meta), 'utf8');
+      await write(`${dep.dir}/package.json`, dep.meta, 'utf8');
 
       await upgrade({
         root,

--- a/commands/sort.js
+++ b/commands/sort.js
@@ -1,6 +1,4 @@
 // @flow
-const {inc} = require('../vendor/semver');
-const {assertProjectDir} = require('../utils/assert-project-dir.js');
 const {getManifest} = require('../utils/get-manifest.js');
 const {getAllDependencies} = require('../utils/get-all-dependencies.js');
 const {sortPackageJson} = require('../utils/sort-package-json.js');
@@ -16,9 +14,9 @@ type Sort = (SortArgs) => Promise<void>
 const sort /*: Sort */ = async ({root}) => {
   const {projects} = await getManifest({root});
   const deps = await getAllDependencies({root, projects});
-	
+
   for (const dep of deps) {
-		await write(`${dep.dir}/package.json`, sortPackageJson(dep.meta), 'utf8');
+    await write(`${dep.dir}/package.json`, sortPackageJson(dep.meta), 'utf8');
   }
 };
 

--- a/commands/sort.js
+++ b/commands/sort.js
@@ -1,0 +1,25 @@
+// @flow
+const {inc} = require('../vendor/semver');
+const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {getManifest} = require('../utils/get-manifest.js');
+const {getAllDependencies} = require('../utils/get-all-dependencies.js');
+const {sortPackageJson} = require('../utils/sort-package-json.js');
+const {write} = require('../utils/node-helpers.js');
+
+/*::
+type SortArgs = {
+  root: string,
+}
+type Sort = (SortArgs) => Promise<void>
+*/
+
+const sort /*: Sort */ = async ({root}) => {
+  const {projects} = await getManifest({root});
+  const deps = await getAllDependencies({root, projects});
+	
+  for (const dep of deps) {
+		await write(`${dep.dir}/package.json`, sortPackageJson(dep.meta), 'utf8');
+  }
+};
+
+module.exports = {sort};

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -44,7 +44,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
           update(meta, 'peerDependencies', name, local.meta.version);
           update(meta, 'optionalDependencies', name, local.meta.version);
         }
-        await write(`${cwd}/package.json`, sortPackageJson(meta), 'utf8');
+        await write(`${cwd}/package.json`, meta, 'utf8');
       })
     );
   }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -43,7 +43,11 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
           update(meta, 'peerDependencies', name, local.meta.version);
           update(meta, 'optionalDependencies', name, local.meta.version);
         }
-        await write(`${cwd}/package.json`, JSON.stringify(meta, null, 2) + '\n', 'utf8');
+        await write(
+          `${cwd}/package.json`,
+          JSON.stringify(meta, null, 2) + '\n',
+          'utf8'
+        );
       })
     );
   }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -3,7 +3,6 @@ const {minVersion, satisfies} = require('../utils/cached-semver');
 const {getManifest} = require('../utils/get-manifest.js');
 const {findLocalDependency} = require('../utils/find-local-dependency.js');
 const {read, write} = require('../utils/node-helpers.js');
-const {sortPackageJson} = require('../utils/sort-package-json.js');
 const {spawn} = require('../utils/node-helpers.js');
 const {node, yarn} = require('../utils/binary-paths.js');
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -43,7 +43,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
           update(meta, 'peerDependencies', name, local.meta.version);
           update(meta, 'optionalDependencies', name, local.meta.version);
         }
-        await write(`${cwd}/package.json`, meta, 'utf8');
+        await write(`${cwd}/package.json`, JSON.stringify(meta, null, 2) + '\n', 'utf8');
       })
     );
   }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const {purge} = require('./commands/purge.js');
 const {check} = require('./commands/check.js');
 const {outdated} = require('./commands/outdated.js');
 const {resolutions} = require('./commands/resolutions.js');
+const {sort} = require('./commands/sort.js');
 const {align} = require('./commands/align.js');
 const {localize} = require('./commands/localize.js');
 const {changes} = require('./commands/changes.js');
@@ -157,6 +158,10 @@ const runCLI /*: RunCLI */ = async argv => {
       resolutions: [
         `Displays list of yarn resolutions`,
         async () => console.log(await resolutions({root: await rootOf(args)})),
+      ],
+      sort: [
+        `Sorts package.json fields`,
+        async () => await sort({root: await rootOf(args)}),
       ],
       align: [
         `Align a project's dependency versions to respect the version policy, if there is one
@@ -338,6 +343,7 @@ module.exports = {
   check: reportMismatchedTopLevelDeps,
   outdated,
   resolutions,
+  sort,
   align,
   localize,
   changes: findChangedTargets,


### PR DESCRIPTION
Add `jz sort` command

Also, don't sort package.jsons on bump or upgrade command

This is to avoid massive diffs due to package.json fields getting sorted in irrelevant packages