### PR TITLE
Adds --limit option for performance reasons to outdated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,11 @@ Shows a report of out-of-sync top level dependencies across projects
 
 List packages that are outdated and their versions
 
-`jazelle outdated`
+`jazelle outdated --json --dedup --limit [number]`
+
+- `--json` - Whether to output as JSON.  Useful for piping to `jq`.  Defaults to `false.`
+- `--dedup` - De-duplicates results by combining used versions into a single result.  Defaults to `false`.
+- `--limit` - Limits the number of external packages to simultaneously resolve with requests to npm.  Defaults to `100`.
 
 ### `jazelle resolutions`
 

--- a/index.js
+++ b/index.js
@@ -147,13 +147,16 @@ const runCLI /*: RunCLI */ = async argv => {
         `Displays deps whose version is behind the latest version
 
         --json                     Whether to print as JSON (e.g. for piping to jq)
-        --dedup                    De-duplicates results by combining used versions into a single result`,
-        async ({json, dedup}) =>
-          outdated({
+        --dedup                    De-duplicates results by combining used versions into a single result
+        --limit                    Limits the number of external packages to simultaneously resolve with requests to npm`,
+        async ({json, dedup, limit}) => {
+          return outdated({
             root: await rootOf(args),
             json: Boolean(json),
             dedup: Boolean(dedup),
-          }),
+            limit: limit ? Number(limit) : undefined,
+          });
+        },
       ],
       resolutions: [
         `Displays list of yarn resolutions`,


### PR DESCRIPTION
Adds a `--limit` option to the `jz outdated` command.  On older machines, the `jz outdated` command can slow things to a crawl so this will throttle the number of `npm info` requests being made simultaneously.

Here are some benchmarks:

```
jz outdated --json --dedup 368.75s user 40.41s system 299% cpu 2:16.40 total
jz outdated --json --dedup --limit 10 321.11s user 33.82s system 55% cpu 10:36.87 total
jz outdated --json --dedup --limit 50 363.30s user 39.50s system 205% cpu 3:15.83 total
jz outdated --json --dedup --limit 100 370.76s user 40.99s system 294% cpu 2:19.70 total
jz outdated --json --dedup --limit 10000 419.34s user 46.53s system 559% cpu 1:23.33 total
```