### PR TITLE
Restore pnp map after upgrade and bump

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -5,6 +5,7 @@ const {findLocalDependency} = require('../utils/find-local-dependency.js');
 const {read, write} = require('../utils/node-helpers.js');
 const {spawn} = require('../utils/node-helpers.js');
 const {node, yarn} = require('../utils/binary-paths.js');
+const {install} = require('./install.js');
 
 /*::
 export type UpgradeArgs = {
@@ -59,6 +60,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
       cwd: root,
       stdio: 'inherit',
     });
+    await install({root, cwd, frozenLockfile: true, conservative: true});
   }
 };
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -60,7 +60,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
       cwd: root,
       stdio: 'inherit',
     });
-    await install({root, cwd, frozenLockfile: true, conservative: true});
+    await install({root, cwd: root, frozenLockfile: true, conservative: true});
   }
 };
 


### PR DESCRIPTION
After running `jz upgrade ...` or `jz bump ...`, the PnP map gets stale and a `jz install` is required. This PR makes it so that the subsequent `jz install` call is not needed.