### PR TITLE
Add support for hasSandboxIO config property in manifest.json

### DIFF
--- a/commands/build.js
+++ b/commands/build.js
@@ -1,5 +1,6 @@
 // @flow
 const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {getManifest} = require('../utils/get-manifest.js');
 const {executeProjectCommand} = require('../utils/execute-project-command.js');
 
 /*::
@@ -14,7 +15,20 @@ export type Build = (BuildArgs) => Promise<void>
 const build /*: Build */ = async ({root, cwd, stdio = 'inherit'}) => {
   await assertProjectDir({dir: cwd});
 
-  await executeProjectCommand({root, cwd, command: 'build', stdio});
+  const {hasSandboxIO} = await getManifest({root});
+
+  if (hasSandboxIO) {
+    // don't throw error on jz build if build configuration is known to write to sandbox
+    await executeProjectCommand({
+      root,
+      cwd,
+      command: 'script',
+      args: ['build'],
+      stdio,
+    });
+  } else {
+    await executeProjectCommand({root, cwd, command: 'build', stdio});
+  }
 };
 
 module.exports = {build};

--- a/utils/get-manifest.js
+++ b/utils/get-manifest.js
@@ -12,6 +12,7 @@ export type Manifest = {
   versionPolicy?: VersionPolicy,
   hooks?: Hooks,
   workspace: "host" | "sandbox",
+  hasSandboxIO?: boolean,
 }
 export type ExceptionMetadata = {
   name: string,


### PR DESCRIPTION
Add support for `hasSandboxIO` config property in manifest.json, which makes `jz build` not error if the underlying command is known to cause IO writes in build sandbox