### PR TITLE
Throw error when --watch flag is passed to test command

### DIFF
--- a/commands/test.js
+++ b/commands/test.js
@@ -17,6 +17,11 @@ const test /*: Test */ = async ({root, cwd, args, stdio = 'inherit'}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);
+  if (params.includes('--watch')) {
+    throw new Error(
+      'Watch flag not supported with jazelle test. Try using jazelle yarn test --watch instead'
+    );
+  }
   await executeProjectCommand({
     root,
     cwd,


### PR DESCRIPTION
Turns out the pass through args are working correctly. The real issue has to do with jest dealing with watching symlinks. Until jest can handle that correctly, we can just throw an error and suggest using jazelle yarn test --watch