### PR TITLE
Add support for retrying bazel commands on BulkTransferException

### DIFF
--- a/tests/fixtures/bazel-command-retries/BUILD.bazel
+++ b/tests/fixtures/bazel-command-retries/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@jazelle//:build-rules.bzl", "jazelle")
+
+jazelle(name = "jazelle", manifest = "manifest.json")
+
+filegroup(
+  name = "yarn",
+  srcs = [".pnp.js", "package.json", "yarn.lock"],
+)

--- a/tests/fixtures/bazel-command-retries/WORKSPACE
+++ b/tests/fixtures/bazel-command-retries/WORKSPACE
@@ -1,0 +1,16 @@
+local_repository(
+    name = "jazelle",
+    path = "../../..",
+)
+
+load("@jazelle//:workspace-rules.bzl", "jazelle_dependencies")
+jazelle_dependencies(
+    node_version = "12.16.1",
+    node_sha256 = {
+        "mac": "",
+        "linux": "",
+        "windows": "",
+    },
+    yarn_version = "1.22.0",
+    yarn_sha256 = "",
+)

--- a/tests/fixtures/bazel-command-retries/manifest.json
+++ b/tests/fixtures/bazel-command-retries/manifest.json
@@ -1,0 +1,3 @@
+{
+  "workspace": "sandbox"
+}

--- a/tests/fixtures/bazel-command-retries/package.json
+++ b/tests/fixtures/bazel-command-retries/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "workspaces": [
+    "projects/a",
+    "projects/b"
+  ]
+}

--- a/tests/fixtures/bazel-command-retries/projects/a/package.json
+++ b/tests/fixtures/bazel-command-retries/projects/a/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@uber/a",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "dependencies": {
+    "@uber/b": "0.0.0"
+  },
+  "scripts": {
+    "build": "echo BulkTransferException && exit 1",
+    "dev": "node dist/index.js",
+    "test": "echo BulkTransferException && exit 1",
+    "lint": "echo BulkTransferException && exit 1",
+    "flow": "echo BulkTransferException && exit 1",
+    "start": "echo 333"
+  }
+}

--- a/tests/fixtures/bazel-command-retries/projects/b/package.json
+++ b/tests/fixtures/bazel-command-retries/projects/b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@uber/b",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo BulkTransferException && exit 1",
+    "dev": "node dist/index.js"
+  }
+}

--- a/tests/fixtures/bazel-command-retries/third_party/jazelle/scripts/build-file-template.js
+++ b/tests/fixtures/bazel-command-retries/third_party/jazelle/scripts/build-file-template.js
@@ -1,0 +1,67 @@
+// @flow
+/*::
+type TemplateArgs = {
+  name: string,
+  path: string,
+  label: string,
+  dependencies: Array<string>,
+}
+type Template = (TemplateArgs) => Promise<string>;
+*/
+const template /*: Template */ = async ({name, path, dependencies}) => `
+package(default_visibility = ["//visibility:public"])
+
+load("@jazelle//:build-rules.bzl", "web_library", "web_binary", "web_executable", "web_test", "flow_test")
+
+web_library(
+    name = "library",
+    deps = [
+        "//:yarn",
+        ${dependencies.map(d => `"${d}",`).join('\n        ')}
+    ],
+    srcs = glob(["**"], exclude = ["dist/**"]),
+)
+
+web_binary(
+    name = "${name}",
+    build = "build",
+    command = "start",
+    deps = [
+        "//${path}:library",
+    ],
+    dist = ["dist"],
+)
+
+web_executable(
+    name = "dev",
+    command = "dev",
+    deps = [
+        "//${path}:library",
+    ],
+)
+
+web_test(
+    name = "test",
+    command = "test",
+    deps = [
+        "//${path}:library",
+    ],
+    gen_srcs = ["generated$"],
+)
+
+web_test(
+    name = "lint",
+    command = "lint",
+    deps = [
+        "//${path}:library",
+    ],
+)
+
+flow_test(
+    name = "flow",
+    deps = [
+        "//${path}:library",
+    ],
+)`;
+
+module.exports = {template};

--- a/tests/index.js
+++ b/tests/index.js
@@ -60,6 +60,11 @@ const {shouldSync, getVersion} = require('../utils/version-onboarding.js');
 const yarnCmds = require('../utils/yarn-commands.js');
 const {sortPackageJson} = require('../utils/sort-package-json');
 
+const noRetryOptions = {
+  numRetries: 0,
+  backoff: 0,
+};
+
 process.on('unhandledRejection', e => {
   console.error(e.stack);
   process.exit(1);
@@ -126,6 +131,8 @@ async function runTests() {
     t(testCheck),
     t(testOutdated),
   ]);
+
+  await t(testBazelCommandRetries);
 
   // run separately to avoid CI error
   await t(testBazelDummy);
@@ -483,6 +490,7 @@ async function testBazelDummy() {
     root: `${tmp}/tmp/bazel`,
     cwd: `${tmp}/tmp/bazel`,
     name: 'target',
+    retryOptions: noRetryOptions,
   });
   const output = `${tmp}/tmp/bazel/bazel-bin/target.sh`;
   assert.equal(await read(output, 'utf8'), 'echo target');
@@ -495,6 +503,7 @@ async function testBazelDummy() {
     cwd: `${tmp}/tmp/bazel`,
     args: [],
     name: 'target',
+    retryOptions: noRetryOptions,
     stdio: ['ignore', testStream, 'ignore'],
   });
   const testMessage = 'Executing tests from //:target';
@@ -508,6 +517,7 @@ async function testBazelDummy() {
     cwd: `${tmp}/tmp/bazel`,
     args: [],
     name: 'target',
+    retryOptions: noRetryOptions,
     stdio: ['ignore', runStream, 'ignore'],
   });
   const runMessage = 'Executing tests from //:target';
@@ -536,6 +546,7 @@ async function testBazelBuild() {
     root: `${tmp}/tmp/bazel-rules`,
     cwd: `${tmp}/tmp/bazel-rules/projects/a`,
     name: 'a',
+    retryOptions: noRetryOptions,
   });
   const output = `${tmp}/tmp/bazel-rules/bazel-bin/projects/a/__jazelle__a.tgz`;
   assert(await exists(output));
@@ -551,6 +562,7 @@ async function testBazelBuild() {
       args: [],
       name: 'test',
       stdio: ['ignore', testStream, testStream],
+      retryOptions: noRetryOptions,
     });
   } catch (e) {
     console.log(await read(testStreamFile, 'utf8'));
@@ -571,6 +583,7 @@ async function testBazelBuild() {
     args: [],
     name: 'test',
     stdio: ['ignore', runStream, 'ignore'],
+    retryOptions: noRetryOptions,
   });
   const runData = await read(runStreamFile, 'utf8');
   assert(runData.includes('\nb\nv12.16.1'));
@@ -584,6 +597,7 @@ async function testBazelBuild() {
     cwd: `${tmp}/tmp/bazel-rules/projects/a`,
     args: [],
     stdio: ['ignore', lintStream, 'ignore'],
+    retryOptions: noRetryOptions,
   });
   const lintData = await read(lintStreamFile, 'utf8');
   assert(lintData.includes('\n111\n'));
@@ -597,6 +611,7 @@ async function testBazelBuild() {
     cwd: `${tmp}/tmp/bazel-rules/projects/a`,
     args: [],
     stdio: ['ignore', flowStream, flowStream],
+    retryOptions: noRetryOptions,
   });
   const flowData = await read(flowStreamFile, 'utf8');
   assert(flowData.includes('a:flow'));
@@ -613,6 +628,116 @@ async function testBazelBuild() {
   });
   const startData = await read(startStreamFile, 'utf8');
   assert(startData.includes('\n333\n'));
+}
+
+async function testBazelCommandRetries() {
+  const cmd = `cp -r ${__dirname}/fixtures/bazel-command-retries/ ${tmp}/tmp/bazel-command-retries`;
+  await exec(cmd);
+
+  const workspaceFile = `${tmp}/tmp/bazel-command-retries/WORKSPACE`;
+  const workspace = await read(workspaceFile, 'utf8');
+  const replaced = workspace.replace(
+    'path = "../../.."',
+    `path = "${__dirname}/.."`
+  );
+  await write(workspaceFile, replaced, 'utf8');
+
+  await install({
+    root: `${tmp}/tmp/bazel-command-retries`,
+    cwd: `${tmp}/tmp/bazel-command-retries/projects/a`,
+  });
+
+  // build
+  const buildStreamFile = `${tmp}/tmp/bazel-command-retries/build-stream.txt`;
+  const buildStream = createWriteStream(buildStreamFile);
+  await new Promise(resolve => buildStream.on('open', resolve));
+  await bazelCmds
+    .build({
+      root: `${tmp}/tmp/bazel-command-retries`,
+      cwd: `${tmp}/tmp/bazel-command-retries/projects/a`,
+      name: 'a',
+      retryOptions: {
+        numRetries: 2,
+        backoff: 3,
+      },
+      stdio: ['ignore', buildStream, buildStream],
+    })
+    .catch(e => {});
+
+  const buildStreamContents = await read(buildStreamFile, 'utf8');
+  assert(
+    buildStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 3ms'
+    )
+  );
+
+  assert(
+    buildStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 6ms'
+    )
+  );
+
+  // test
+  const testStreamFile = `${tmp}/tmp/bazel-command-retries/test-stream.txt`;
+  const testStream = createWriteStream(testStreamFile);
+  await new Promise(resolve => testStream.on('open', resolve));
+  await bazelCmds
+    .test({
+      args: [],
+      root: `${tmp}/tmp/bazel-command-retries`,
+      cwd: `${tmp}/tmp/bazel-command-retries/projects/a`,
+      name: 'test',
+      retryOptions: {
+        numRetries: 2,
+        backoff: 3,
+      },
+      stdio: ['ignore', testStream, testStream],
+    })
+    .catch(e => {});
+
+  const testStreamContents = await read(testStreamFile, 'utf8');
+  assert(
+    testStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 3ms'
+    )
+  );
+
+  assert(
+    testStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 6ms'
+    )
+  );
+
+  // lint
+  const lintStreamFile = `${tmp}/tmp/bazel-command-retries/lint-stream.txt`;
+  const lintStream = createWriteStream(lintStreamFile);
+  await new Promise(resolve => lintStream.on('open', resolve));
+  await bazelCmds
+    .lint({
+      args: [],
+      root: `${tmp}/tmp/bazel-command-retries`,
+      cwd: `${tmp}/tmp/bazel-command-retries/projects/a`,
+      name: 'lint',
+      retryOptions: {
+        numRetries: 2,
+        backoff: 3,
+      },
+      stdio: ['ignore', lintStream, lintStream],
+    })
+    .catch(e => {});
+
+  const lintStreamContents = await read(lintStreamFile, 'utf8');
+  assert(
+    lintStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 3ms'
+    )
+  );
+
+  assert(
+    lintStreamContents.includes(
+      'BulkTransferException detected - retrying command with backoff 6ms'
+    )
+  );
 }
 
 async function testBinaryPaths() {

--- a/utils/bazel-commands.js
+++ b/utils/bazel-commands.js
@@ -1,9 +1,106 @@
 // @flow
 const {relative, basename, dirname} = require('path');
 const {bazel, node} = require('./binary-paths.js');
+const proc = require('child_process');
 const {spawn} = require('./node-helpers.js');
+const {
+  chunksToLinesAsync,
+  streamWrite,
+} = require('../vendor/@rauschma/stringio');
 
 const startupFlags = ['--host_jvm_args=-Xmx15g'];
+
+const defaultRetryOptions = {
+  numRetries: 5,
+  backoff: 1000,
+};
+
+/*::
+type RetryOptions = {
+  numRetries: number,
+  backoff: number
+}
+*/
+
+const spawnBazelCommand = (
+  args,
+  {cwd, stdio},
+  retryOptions = defaultRetryOptions
+) => {
+  if (typeof process.env.NODE_OPTIONS !== 'string') {
+    process.env.NODE_OPTIONS = '--max_old_space_size=16384';
+  } else if (!process.env.NODE_OPTIONS.includes('--max_old_space_size')) {
+    // $FlowFixMe
+    process.env.NODE_OPTIONS += ' --max_old_space_size=16384';
+  }
+  const errorWithSyncStackTrace = new Error();
+  let shouldRetry = false;
+
+  const child = proc.spawn(bazel, [...startupFlags, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+    cwd,
+  });
+
+  async function handleOutput(readable, writable) {
+    for await (const line of chunksToLinesAsync(readable)) {
+      await streamWrite(writable, line);
+      if (line.includes('BulkTransferException')) {
+        shouldRetry = true;
+      }
+    }
+  }
+
+  let outStream = process.stdout;
+  let errStream = process.stderr;
+
+  if (Array.isArray(stdio)) {
+    if (typeof stdio[1] === 'object') {
+      outStream = stdio[1];
+    }
+    if (typeof stdio[2] === 'object') {
+      errStream = stdio[2];
+    }
+  }
+
+  handleOutput(child.stdout, outStream);
+  handleOutput(child.stderr, errStream);
+
+  return new Promise((resolve, reject) => {
+    child.on('error', e => {
+      reject(new Error(e));
+    });
+    child.on('close', code => {
+      if (code > 0) {
+        if (shouldRetry && retryOptions.numRetries > 0) {
+          streamWrite(
+            outStream,
+            `BulkTransferException detected - retrying command with backoff ${retryOptions.backoff}ms`
+          );
+          setTimeout(() => {
+            retryOptions.backoff = retryOptions.backoff * 2;
+            retryOptions.numRetries = retryOptions.numRetries - 1;
+            return spawnBazelCommand(args, {cwd, stdio}, retryOptions)
+              .then(resolve)
+              .catch(reject);
+          }, retryOptions.backoff);
+        } else {
+          const commandString = 'bazel ' + args.join(' ');
+          errorWithSyncStackTrace.message = `Process failed ${cwd}with exit code ${code}: ${commandString}`;
+          // $FlowFixMe - maybe create specific error class to contain exit code?
+          errorWithSyncStackTrace.status = code;
+          reject(errorWithSyncStackTrace);
+        }
+      } else {
+        resolve();
+      }
+    });
+    process.on('exit', () => {
+      // $FlowFixMe flow typedef is missing .exitCode
+      if (child.exitCode === null) child.kill();
+    });
+  });
+};
 
 /*::
 import type {Stdio} from './node-helpers.js';
@@ -13,24 +110,26 @@ export type BuildArgs = {
   cwd: string,
   name?: string,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 export type Build = (BuildArgs) => Promise<void>;
 */
+
 const build /*: Build */ = async ({
   root,
   cwd,
   name = basename(cwd),
   stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
 }) => {
   cwd = relative(root, cwd);
-  await spawn(
-    bazel,
-    [...startupFlags, 'build', `//${cwd}:${name}`, '--sandbox_debug'],
+  await spawnBazelCommand(
+    ['build', `//${cwd}:${name}`, '--sandbox_debug'],
     {
-      stdio,
-      env: process.env,
       cwd: root,
-    }
+      stdio,
+    },
+    retryOptions
   );
 };
 
@@ -41,6 +140,7 @@ export type TestArgs = {
   args: Array<string>,
   name?: string,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 type Test = (TestArgs) => Promise<void>;
 */
@@ -50,23 +150,14 @@ const test /*: Test */ = async ({
   args,
   name = 'test',
   stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
 }) => {
   cwd = relative(root, cwd);
   const testParams = args.map(arg => `--test_arg=${arg}`);
-  await spawn(
-    bazel,
-    [
-      ...startupFlags,
-      'run',
-      `//${cwd}:${name}`,
-      '--sandbox_debug',
-      ...testParams,
-    ],
-    {
-      stdio,
-      env: process.env,
-      cwd: root,
-    }
+  await spawnBazelCommand(
+    ['run', `//${cwd}:${name}`, '--sandbox_debug', ...testParams],
+    {cwd: root, stdio},
+    retryOptions
   );
 };
 
@@ -77,6 +168,7 @@ export type RunArgs = {
   args: Array<string>,
   name?: string,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 type Run = (RunArgs) => Promise<void>;
 */
@@ -86,23 +178,14 @@ const run /*: Run */ = async ({
   args,
   name = basename(cwd),
   stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
 }) => {
   cwd = relative(root, cwd);
   const runParams = args.length > 0 ? ['--', ...args] : [];
-  await spawn(
-    bazel,
-    [
-      ...startupFlags,
-      'run',
-      `//${cwd}:${name}`,
-      '--sandbox_debug',
-      ...runParams,
-    ],
-    {
-      stdio,
-      env: process.env,
-      cwd: root,
-    }
+  await spawnBazelCommand(
+    ['run', `//${cwd}:${name}`, '--sandbox_debug', ...runParams],
+    {cwd: root, stdio},
+    retryOptions
   );
 };
 
@@ -112,11 +195,18 @@ export type DevArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 type Dev = (DevArgs) => Promise<void>;
 */
-const dev /*: Dev */ = async ({root, cwd, args, stdio = 'inherit'}) => {
-  await run({root, cwd, args, name: 'dev', stdio});
+const dev /*: Dev */ = async ({
+  root,
+  cwd,
+  args,
+  stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
+}) => {
+  await run({root, cwd, args, name: 'dev', stdio, retryOptions});
 };
 
 /*::
@@ -125,11 +215,18 @@ export type LintArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 type Lint = (LintArgs) => Promise<void>;
 */
-const lint /*: Lint */ = async ({root, cwd, args, stdio = 'inherit'}) => {
-  await run({root, cwd, args, name: 'lint', stdio});
+const lint /*: Lint */ = async ({
+  root,
+  cwd,
+  args,
+  stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
+}) => {
+  await run({root, cwd, args, name: 'lint', stdio, retryOptions});
 };
 
 /*::
@@ -138,11 +235,18 @@ export type FlowArgs = {
   cwd: string,
   args: Array<string>,
   stdio?: Stdio,
+  retryOptions?: RetryOptions,
 };
 type Flow = (FlowArgs) => Promise<void>;
 */
-const flow /*: Flow */ = async ({root, cwd, args, stdio = 'inherit'}) => {
-  await run({root, cwd, args, name: 'flow', stdio});
+const flow /*: Flow */ = async ({
+  root,
+  cwd,
+  args,
+  stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
+}) => {
+  await run({root, cwd, args, name: 'flow', stdio, retryOptions});
 };
 
 /*::
@@ -155,7 +259,13 @@ export type StartArgs = {
 type Start = (StartArgs) => Promise<void>;
 */
 const start /*: Start */ = async ({root, cwd, args, stdio = 'inherit'}) => {
-  await run({root, cwd, args, stdio});
+  await run({
+    root,
+    cwd,
+    args,
+    stdio,
+    retryOptions: {numRetries: 0, backoff: 0},
+  });
 };
 
 /*::
@@ -186,6 +296,7 @@ export type ScriptArgs = {
   command: string,
   args: Array<string>,
   stdio?: Stdio,
+  retryOptions?: RetryOptions
 };
 type Script = (ScriptArgs) => Promise<void>;
 */
@@ -195,8 +306,16 @@ const script /*: Script */ = async ({
   command,
   args,
   stdio = 'inherit',
+  retryOptions = defaultRetryOptions,
 }) => {
-  await run({root, cwd, args: [command, ...args], name: 'script', stdio});
+  await run({
+    root,
+    cwd,
+    args: [command, ...args],
+    name: 'script',
+    stdio,
+    retryOptions,
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
This adds support for automatically retrying bazel commands when receiving a BulkTransferException. By default it will retry up to 5 times with an exponential backoff starting at 1000ms. Tests included