### PR TITLE
Don't upgrade peerdependencies

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -39,9 +39,9 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
             throw new Error(error);
           }
 
+          // don't update peerDependencies, we don't want to inadvertedly cause downstreams to have multiple versions of things
           update(meta, 'dependencies', name, local.meta.version);
           update(meta, 'devDependencies', name, local.meta.version);
-          update(meta, 'peerDependencies', name, local.meta.version);
           update(meta, 'optionalDependencies', name, local.meta.version);
         }
         await write(


### PR DESCRIPTION
We want the consumer to have full control over peer dependency versions, in cases where things are consumed outside of the jazelle-powered repo.

While it's fine to track peer dep versions closely for projects *in* the monorepo, this means projects outside must also upgrade at similar cadence in order to avoid incurring two versions of same libraries in cases where things are depended on transitively