### PR TITLE
don't overwrite dependency version on bump if it's set to `*`

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -68,7 +68,7 @@ const update = (meta, type, name, version, from) => {
   if (meta[type] && meta[type][name]) {
     const min = minVersion(meta[type][name]);
     const inRange = !from || satisfies(min, from);
-    if (inRange) meta[type][name] = version;
+    if (inRange && meta[type][name] !== '*') meta[type][name] = version;
   }
 };
 


### PR DESCRIPTION
If a package has a dependency version set to `*` and the `jz upgrade` command is run, there's no need to pin to the new version, since `*` already means the same thing.

By allowing `*` to stay untouched on upgrades allows a library owner to run `jz bump` without touching downstream package.json files. This is helpful if the repo has code review tooling setup and the library owners don't want to wait for reviews from consumers for whatever reason. It is still possible to determine that downstreams are affected via querying the bazel graph, regardless.

A consumer can conversely require to be a reviewer by not using `*` as a version, which would cause `jz bump` to change the dep version in the consumer's package.json, thus marking the project as needing review.