### PR TITLE
Find local deps if they have workspace:* set as a version

### DIFF
--- a/utils/get-local-dependencies.js
+++ b/utils/get-local-dependencies.js
@@ -54,7 +54,8 @@ function findDependencies(data, target, depth = 1, set = new Set()) {
       Object.keys(deps).forEach(dep => {
         const found = data.find(item => {
           return (
-            item.meta.name === dep && satisfies(item.meta.version, deps[dep])
+            item.meta.name === dep &&
+            (satisfies(item.meta.version, deps[dep]) || deps[dep].includes('*'))
           );
         });
         if (found && !set.has(found.dir)) {


### PR DESCRIPTION
Running `jz add something` removes things from BUILD.bazel file if they have their version set to `workspace:*` (though `jz install` rectifies it). This PR fixes the incorrect pruning on jz add