### PR TITLE
Add skip_pnp option to web-monorepo rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1558,6 +1558,7 @@ web_binary(
   deps = [string],
   dist = string,
   preserve_symlinks = string,
+  skip_pnp = boolean,
 )
 ```
 
@@ -1566,6 +1567,7 @@ web_binary(
 - `deps` - A list of target labels that are dependencies of this rule
 - `dist` - The name of the output folder where compiled assets are saved to
 - `preserve_symlinks` - Whether to use the Node PRESERVE_SYMLINKS flag. Set to `"1"` for true or `""` for false.
+- `skip_pnp` - Boolean flag to bypass the auto require of the Yarn 2 `.pnp.cjs` file when executing Node commands.
 
 This rule consumes transitive files from the `DefaultInfo(files)` provider of targets specified by `deps`. If the transitive files include `output.tgz` files, they are extracted into the root folder of their respective project (in the Bazel sandbox).
 

--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -88,9 +88,13 @@ function runCommand(command, args = []) {
     execOrExit(`${node} ${yarn} run ${command} ${params}`, options);
   } else {
     // Support `build = "${NODE} ${ROOT_DIR}/foo.js"` as a web_binary build argument (instead of a package.json script name)
-    const cmd = command
-      .replace(/\$\{NODE\}/g, `${node} -r ${join(rootDir, '.pnp.cjs')}`)
-      .replace(/\$\{ROOT_DIR\}/g, rootDir);
+    let cmd = command;
+    if (process.env.NODE_SKIP_PNP === '1') {
+      cmd = cmd.replace(/\$\{NODE\}/g, `${node}`);
+    } else {
+      cmd = cmd.replace(/\$\{NODE\}/g, `${node} -r ${join(rootDir, '.pnp.cjs')}`);
+    }
+    cmd = cmd.replace(/\$\{ROOT_DIR\}/g, rootDir);
     execOrExit(cmd, options);
   }
 }

--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -92,7 +92,10 @@ function runCommand(command, args = []) {
     if (process.env.NODE_SKIP_PNP === '1') {
       cmd = cmd.replace(/\$\{NODE\}/g, `${node}`);
     } else {
-      cmd = cmd.replace(/\$\{NODE\}/g, `${node} -r ${join(rootDir, '.pnp.cjs')}`);
+      cmd = cmd.replace(
+        /\$\{NODE\}/g,
+        `${node} -r ${join(rootDir, '.pnp.cjs')}`
+      );
     }
     cmd = cmd.replace(/\$\{ROOT_DIR\}/g, rootDir);
     execOrExit(cmd, options);

--- a/rules/web-monorepo.bzl
+++ b/rules/web-monorepo.bzl
@@ -79,6 +79,7 @@ def _web_binary_impl(ctx):
     export NODE=$(cd `dirname '{node}'` && pwd)/$(basename '{node}');
     export OUT=$(cd `dirname '{output}'` && pwd)/$(basename '{output}');
     export BAZEL_BIN_DIR=$(cd '{bindir}' && pwd);
+    export NODE_SKIP_PNP={skip_pnp};
     $NODE '{untar_script}';
     $NODE --max_old_space_size=65536 '{build}' "$PWD" "$CWD" "$BAZEL_BIN_DIR" '{command}' '{dist}' '' "$OUT" $@;
     """.format(
@@ -91,6 +92,7 @@ def _web_binary_impl(ctx):
       preserve_symlinks = ctx.attr.preserve_symlinks,
       untar_script = ctx.files._untar_script[0].path,
       build = ctx.files._script[0].path,
+      skip_pnp = 1 if ctx.attr.skip_pnp else 0,
     ),
     tools = ctx.files._node,
     inputs = build_deps,
@@ -138,6 +140,9 @@ web_binary = rule(
     "_script": attr.label(
       allow_files = True,
       default = Label("//:rules/execute-command.js"),
+    ),
+    "skip_pnp": attr.bool(
+      default = False,
     ),
   },
   executable = True,


### PR DESCRIPTION
Adds an additional option to bypass the auto loading of the pnp.js file when commands are being run with jazelle. Reason being some scripts can be optimized to use only NodeJS libraries and not require any node_modules to run and this vastly improves script start up performance if the pnp.js file is large.

The flag is set to opt in so scripts need to explicitly define `skip_pnp` and set it to `True` in order to activate this.