### PR TITLE
Add `bool_shouldinstall` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,7 +1277,7 @@ Installation hooks run shell scripts before/after dependency installation.
 
 ### Boolean hooks
 
-Boolean hooks are a special type of hook that can conditionally enable/disable jazelle behavior. They work by emitting `true` or `false` to stdout (must be the last thing emitted in the script)
+Boolean hooks are a special type of hook that can conditionally enable/disable jazelle behavior. They work by emitting `true` or `false` to stdout (must be the last thing emitted in the script).
 
 ```json
 {
@@ -1285,6 +1285,20 @@ Boolean hooks are a special type of hook that can conditionally enable/disable j
     "bool_shouldinstall": "echo false",
   }
 }
+```
+
+Example `bool_shouldinstall` hook:
+
+```sh
+#!/usr/bin/env bash
+
+if ./pull_yarn_cache.sh; then
+  # dependency cache was successfully pulled; don't install
+  echo 'false'
+  exit 0
+fi
+
+echo 'true'
 ```
 
 ### Version policy

--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,7 @@ Finds the absolute path of the monorepo root folder
 - [Workspace](#workspace)
 - [Scaffold hooks](#scaffold-hooks)
 - [Installation hooks](#installation-hooks)
+- [Boolean hooks](#boolean-hooks)
 - [Version policy](#version-policy)
 - [Build file template](#build-file-template)
 
@@ -1269,6 +1270,19 @@ Installation hooks run shell scripts before/after dependency installation.
     "preinstall": "echo before",
     "postinstall": "echo after",
     "postcommand": "echo after command",
+  }
+}
+```
+
+
+### Boolean hooks
+
+Boolean hooks are a special type of hook that can conditionally enable/disable jazelle behavior. They work by emitting `true` or `false` to stdout (must be the last thing emitted in the script)
+
+```json
+{
+  "hooks": {
+    "bool_shouldinstall": "echo false",
   }
 }
 ```

--- a/commands/install.js
+++ b/commands/install.js
@@ -55,6 +55,20 @@ const install /*: Install */ = async ({
   if (!isRootInstall) {
     validateRegistration({root, cwd, projects});
   }
+
+  if (hooks.bool_shouldinstall) {
+    const hookResult = await executeHook(hooks.bool_shouldinstall, root, {
+      isBooleanHook: true,
+    });
+
+    if (hookResult === false) {
+      console.log(
+        '`bool_shouldinstall` hook returned `false`; skipping install'
+      );
+      return;
+    }
+  }
+
   const all = await getAllDependencies({root, projects});
 
   const deps = isRootInstall

--- a/utils/execute-hook.js
+++ b/utils/execute-hook.js
@@ -4,23 +4,45 @@ const {node} = require('./binary-paths.js');
 const {exec} = require('./node-helpers.js');
 
 /*::
-type Env = {}
-type ExecuteHook = (?string, string, ?Env) => Promise<void>;
+type Opts = {
+  env?: {},
+  isBooleanHook?: boolean,
+};
+type ExecuteHook = (?string, string, ?Opts) => Promise<boolean|void>;
 */
-const executeHook /*: ExecuteHook */ = async (hook, root, env = {}) => {
+const executeHook /*: ExecuteHook */ = async (hook, root, opts = {}) => {
+  opts = {
+    env: {},
+    isBooleanHook: false,
+    ...opts,
+  };
+
   const nodePath = dirname(node);
   if (typeof hook === 'string') {
     // prioritize hermetic Node version over system version
-    const options = {
+    const execOpts = {
       env: {
         ...process.env,
         PATH: `${nodePath}:${String(process.env.PATH)}`,
-        ...env,
+        ...opts.env,
       },
       cwd: root,
     };
-    const stdio = [process.stdout, process.stderr];
-    await exec(hook, options, stdio);
+
+    if (opts.isBooleanHook) {
+      const output = await exec(hook, execOpts);
+      const lines = output.split('\n').filter(Boolean);
+      const lastLine = lines[lines.length - 1];
+
+      if (lastLine === 'true') {
+        return true;
+      } else if (lastLine === 'false') {
+        return false;
+      }
+    } else {
+      const stdio = [process.stdout, process.stderr];
+      await exec(hook, execOpts, stdio);
+    }
   }
 };
 


### PR DESCRIPTION
This allows for conditionally skipping the install when running `jz install` or `jz ci`. Useful for intercepting install process to pull a dependency cache instead