### PR TITLE
Fix test

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -754,14 +754,17 @@ async function testFindChangedTargets() {
       cwd: `${tmp}/tmp/find-changed-targets/bazel/c`,
     });
     const targets = await findChangedTargets({root, files, format: 'targets'});
-    assert.deepEqual(targets, [
-      '//b:test',
-      '//b:lint',
-      '//b:flow',
-      '//a:test',
-      '//a:lint',
-      '//a:flow',
-    ]);
+    assert.deepEqual(
+      targets.sort(),
+      [
+        '//b:test',
+        '//b:lint',
+        '//b:flow',
+        '//a:test',
+        '//a:lint',
+        '//a:flow',
+      ].sort()
+    );
   }
   {
     const root = `${__dirname}/fixtures/find-changed-targets/no-target`;


### PR DESCRIPTION
Seems this test [started failing](https://github.com/uber-web/jazelle/runs/4971085324?check_suite_focus=true#step:7:135) with the latest version of bazel (and tests implicitly use the latest)