### PR TITLE
Run root script instead of erroring if a user tries to run the root script from a project folder

### DIFF
--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -26,7 +26,9 @@ const [
 ] = process.argv;
 
 const {scripts = {}} = JSON.parse(read(`${main}/package.json`, 'utf8'));
-const {scripts: rootScripts = {}} = JSON.parse(read(`${rootDir}/package.json`, 'utf8'));
+const {scripts: rootScripts = {}} = JSON.parse(
+  read(`${rootDir}/package.json`, 'utf8')
+);
 
 if (out) {
   runCommands(command, args);
@@ -89,19 +91,24 @@ function runCommand(command, args = []) {
     execOrExit(`${node} ${yarn} run ${command} ${params}`, options);
   } else if (command.includes('${NODE}')) {
     // Support `build = "${NODE} ${ROOT_DIR}/foo.js"` as a web_binary build argument (instead of a package.json script name)
-    const exe = process.env.NODE_SKIP_PNP === '1'
-      ? `${node}`
-      : `${node} -r ${join(rootDir, '.pnp.cjs')}`;
+    const exe =
+      process.env.NODE_SKIP_PNP === '1'
+        ? `${node}`
+        : `${node} -r ${join(rootDir, '.pnp.cjs')}`;
     const cmd = command
       .replace(/\$\{NODE\}/g, exe)
       .replace(/\$\{ROOT_DIR\}/g, rootDir);
     execOrExit(cmd, options);
   } else if (command in rootScripts) {
     // if command exists at root level but not at project level, run the root level command instead of erroring
-    execOrExit(`${node} ${yarn} run ${command} ${params}`, {cwd: rootDir, env: process.env, stdio: 'inherit'});
+    execOrExit(`${node} ${yarn} run ${command} ${params}`, {
+      cwd: rootDir,
+      env: process.env,
+      stdio: 'inherit',
+    });
   } else {
     // do not allow running arbitrary shell commands
-    // users should run such commands directly instead of running them through jazelle 
+    // users should run such commands directly instead of running them through jazelle
     console.error('Invalid command: ' + command);
     process.exitCode = 1;
   }


### PR DESCRIPTION
Currently, if a user terminal is in a project folder and they run a command that is meant to be run from the root folder, an error occurs (or worse, if a global executable of the same name exists, that runs instead).

This change makes is so that running a root script from a non-root folder falls back to running the expected command instead of causing surprising things to happen