### PR TITLE
Emit boolean hooks to stdout

### DIFF
--- a/commands/install.js
+++ b/commands/install.js
@@ -62,9 +62,6 @@ const install /*: Install */ = async ({
     });
 
     if (hookResult === false) {
-      console.log(
-        '`bool_shouldinstall` hook returned `false`; skipping install'
-      );
       return;
     }
   }

--- a/utils/execute-hook.js
+++ b/utils/execute-hook.js
@@ -3,6 +3,11 @@ const {dirname} = require('path');
 const {node} = require('./binary-paths.js');
 const {exec} = require('./node-helpers.js');
 
+function clearPrevLine() {
+  process.stdout.moveCursor(0, -1);
+  process.stdout.clearLine(1);
+}
+
 /*::
 type Opts = {
   env?: {},
@@ -29,19 +34,19 @@ const executeHook /*: ExecuteHook */ = async (hook, root, opts = {}) => {
       cwd: root,
     };
 
+    const output = await exec(hook, execOpts, [process.stdout, process.stderr]);
+
     if (opts.isBooleanHook) {
-      const output = await exec(hook, execOpts);
       const lines = output.split('\n').filter(Boolean);
       const lastLine = lines[lines.length - 1];
 
       if (lastLine === 'true') {
+        clearPrevLine();
         return true;
       } else if (lastLine === 'false') {
+        clearPrevLine();
         return false;
       }
-    } else {
-      const stdio = [process.stdout, process.stderr];
-      await exec(hook, execOpts, stdio);
     }
   }
 };


### PR DESCRIPTION
The stdout/err was originally hidden because the hook has to emit `true` or `false` on its last line, but since there's been a lot of confusion internally with the message jazelle outputs, this changes it to emit the hook's stdout/err and just clear the last line