### PR TITLE
Fix clearPrevLine in executeHook

### DIFF
--- a/utils/execute-hook.js
+++ b/utils/execute-hook.js
@@ -5,9 +5,9 @@ const {exec} = require('./node-helpers.js');
 
 function clearPrevLine() {
   // $FlowFixMe
-  process.stdout.moveCursor(0, -1);
+  if (process.stdout.moveCursor) process.stdout.moveCursor(0, -1);
   // $FlowFixMe
-  process.stdout.clearLine(1);
+  if (process.stdout.clearLine) process.stdout.clearLine(1);
 }
 
 /*::


### PR DESCRIPTION
`jz install` was running in a sub process and threw:

```
process.stdout.moveCursor is not a function
```

so it seems there are some cases where these utilities aren't available