### PR TITLE
[jz bump] Ignore packages using `workspace:*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ Runs a bash script in all projects, parallelizing across CPUs
 
 ### `jazelle bump`
 
-Bumps a package and its dependencies to the next version. It also updates all matching local packages to match
+Bumps a package and its dependencies to the next version. It also updates all matching local packages to match. Note that if a local package depends on the bumped package via `workspace:*`, it won't be touched.
 
 `jazelle bump [type] [--frozePackageJson] --cwd [cwd]`
 

--- a/commands/bump.js
+++ b/commands/bump.js
@@ -35,7 +35,7 @@ const bump /*: Bump */ = async ({
     }),
   ]);
   const dep = deps.find(({dir}) => dir === cwd);
-  const downstreams = await getDownstreams(deps, dep);
+  const downstreams = await getDownstreams(deps, dep, true);
   downstreams.push(dep);
 
   const types = /^(major|premajor|minor|preminor|patch|prepatch|prerelease|none)$/;

--- a/commands/bump.js
+++ b/commands/bump.js
@@ -35,7 +35,11 @@ const bump /*: Bump */ = async ({
     }),
   ]);
   const dep = deps.find(({dir}) => dir === cwd);
-  const downstreams = await getDownstreams(deps, dep, true);
+  const downstreams = await getDownstreams({
+    deps,
+    dep,
+    excludeWorkspaceDeps: true,
+  });
   downstreams.push(dep);
 
   const types = /^(major|premajor|minor|preminor|patch|prepatch|prerelease|none)$/;

--- a/tests/index.js
+++ b/tests/index.js
@@ -917,7 +917,7 @@ async function testGetDownstreams() {
       depth: 1,
     },
   ];
-  const downstreams = getDownstreams(deps, deps[0]);
+  const downstreams = getDownstreams({deps, dep: deps[0]});
   assert.deepEqual(downstreams, deps.slice(1));
 }
 
@@ -959,7 +959,11 @@ async function testGetDownstreamsExclude() {
       depth: 2,
     },
   ];
-  const downstreams = getDownstreams(deps, deps[0], true);
+  const downstreams = getDownstreams({
+    deps,
+    dep: deps[0],
+    excludeWorkspaceDeps: true,
+  });
   // `d` should be the only downstream returned, since b and c are
   // downstream as a result of `workspace:*` and should be excluded
   assert.deepEqual(downstreams, [deps[3]]);

--- a/tests/index.js
+++ b/tests/index.js
@@ -108,6 +108,7 @@ async function runTests() {
     t(testGenerateBazelBuildRules),
     t(testGenerateBazelBuildRulesUpdate),
     t(testGetDownstreams),
+    t(testGetDownstreamsExclude),
     t(testGetManifest),
     t(testGetLocalDependencies),
     t(testGetRootDir),
@@ -918,6 +919,50 @@ async function testGetDownstreams() {
   ];
   const downstreams = getDownstreams(deps, deps[0]);
   assert.deepEqual(downstreams, deps.slice(1));
+}
+
+async function testGetDownstreamsExclude() {
+  const deps = [
+    {
+      dir: `${tmp}/tmp/get-downstreams/a`,
+      meta: {
+        name: 'a',
+        version: '0.0.0',
+      },
+      depth: 1,
+    },
+    {
+      dir: `${tmp}/tmp/get-downstreams/b`,
+      meta: {
+        name: 'b',
+        version: '0.0.0',
+        dependencies: {a: 'workspace:*'},
+      },
+      depth: 3,
+    },
+    {
+      dir: `${tmp}/tmp/get-downstreams/c`,
+      meta: {
+        name: 'c',
+        version: '0.0.0',
+        dependencies: {b: '0.0.0'},
+      },
+      depth: 2,
+    },
+    {
+      dir: `${tmp}/tmp/get-downstreams/d`,
+      meta: {
+        name: 'd',
+        version: '0.0.0',
+        dependencies: {a: '0.0.0'},
+      },
+      depth: 2,
+    },
+  ];
+  const downstreams = getDownstreams(deps, deps[0], true);
+  // `d` should be the only downstream returned, since b and c are
+  // downstream as a result of `workspace:*` and should be excluded
+  assert.deepEqual(downstreams, [deps[3]]);
 }
 
 async function testGetLocalDependencies() {

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -161,7 +161,7 @@ const findChangedBazelTargets = async ({root, files}) => {
       for (const target of set) {
         const dep = allProjects.find(project => project.dir === target);
         if (dep) {
-          const downstreamDeps = getDownstreams(allProjects, dep);
+          const downstreamDeps = getDownstreams({deps: allProjects, dep});
           for (const downstreamDep of downstreamDeps) {
             changeSet.add(downstreamDep.dir);
           }

--- a/utils/get-downstreams.js
+++ b/utils/get-downstreams.js
@@ -2,13 +2,17 @@
 /*::
 import type {Metadata} from './get-local-dependencies.js';
 
-export type GetDownstreams = (Array<Metadata>, Metadata, ?boolean) => Array<Metadata>
+export type GetDownstreams = ({
+  deps: Array<Metadata>,
+  dep: Metadata,
+  excludeWorkspaceDeps?: boolean
+}) => Array<Metadata>
 */
-const getDownstreams /*: GetDownstreams */ = (
+const getDownstreams /*: GetDownstreams */ = ({
   deps,
   dep,
-  excludeWorkspaceDeps = false
-) => {
+  excludeWorkspaceDeps = false,
+}) => {
   return getDedupedDownstreams(deps, dep, excludeWorkspaceDeps).slice(1);
 };
 const getDedupedDownstreams = (

--- a/utils/get-downstreams.js
+++ b/utils/get-downstreams.js
@@ -2,7 +2,7 @@
 /*::
 import type {Metadata} from './get-local-dependencies.js';
 
-export type GetDownstreams = (Array<Metadata>, Metadata) => Array<Metadata>
+export type GetDownstreams = (Array<Metadata>, Metadata, ?boolean) => Array<Metadata>
 */
 const getDownstreams /*: GetDownstreams */ = (
   deps,

--- a/utils/get-downstreams.js
+++ b/utils/get-downstreams.js
@@ -4,10 +4,19 @@ import type {Metadata} from './get-local-dependencies.js';
 
 export type GetDownstreams = (Array<Metadata>, Metadata) => Array<Metadata>
 */
-const getDownstreams /*: GetDownstreams */ = (deps, dep) => {
-  return getDedupedDownstreams(deps, dep).slice(1);
+const getDownstreams /*: GetDownstreams */ = (
+  deps,
+  dep,
+  excludeWorkspaceDeps = false
+) => {
+  return getDedupedDownstreams(deps, dep, excludeWorkspaceDeps).slice(1);
 };
-const getDedupedDownstreams = (deps, dep, set = new Set()) => {
+const getDedupedDownstreams = (
+  deps,
+  dep,
+  excludeWorkspaceDeps,
+  set = new Set()
+) => {
   const downstreams = [dep];
   if (!set.has(dep.dir)) {
     set.add(dep.dir);
@@ -16,8 +25,14 @@ const getDedupedDownstreams = (deps, dep, set = new Set()) => {
         ...item.meta.dependencies,
         ...item.meta.devDependencies,
       };
-      if (dep.meta.name in names && !set.has(item.dir)) {
-        downstreams.push(...getDedupedDownstreams(deps, item, set));
+      if (
+        dep.meta.name in names &&
+        (names[dep.meta.name] !== 'workspace:*' || !excludeWorkspaceDeps) &&
+        !set.has(item.dir)
+      ) {
+        downstreams.push(
+          ...getDedupedDownstreams(deps, item, excludeWorkspaceDeps, set)
+        );
       }
     }
   }

--- a/utils/yarn-commands.js
+++ b/utils/yarn-commands.js
@@ -37,7 +37,7 @@ const buildCacheable = async ({root, dep, deps, stdio}) => {
       await spawn(node, [yarn, 'build'], {stdio, env: process.env, cwd: dir});
     }
 
-    getDownstreams(deps, dep).forEach(d => {
+    getDownstreams({deps, dep}).forEach(d => {
       // check depth to ensure we only invalidate downstreams, not cyclical deps
       if (dep.depth < d.depth) cache.invalidate(d.dir);
     });


### PR DESCRIPTION
Ticket: https://t3.uberinternal.com/browse/WPT-8662

`jz bump` errors out when it tries to update local downstreams that depending on the package via `workspace:*`. This updates it to just ignore those packages and not touch them