### PR TITLE
[changes] return all web_* rules for `targets` format

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -758,12 +758,16 @@ async function testFindChangedTargets() {
     assert.deepEqual(
       targets.sort(),
       [
-        '//b:test',
-        '//b:lint',
-        '//b:flow',
-        '//a:test',
+        '//a:a',
+        '//a:dev',
+        '//a:library',
         '//a:lint',
-        '//a:flow',
+        '//a:test',
+        '//b:b',
+        '//b:dev',
+        '//b:library',
+        '//b:lint',
+        '//b:test',
       ].sort()
     );
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -760,11 +760,13 @@ async function testFindChangedTargets() {
       [
         '//a:a',
         '//a:dev',
+        '//a:flow',
         '//a:library',
         '//a:lint',
         '//a:test',
         '//b:b',
         '//b:dev',
+        '//b:flow',
         '//b:library',
         '//b:lint',
         '//b:test',

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -78,7 +78,7 @@ const findChangedBazelTargets = async ({root, files}) => {
   const opts = {cwd: root, maxBuffer: 1e9};
   if (workspace === 'sandbox') {
     if (lines.includes('WORKSPACE') || lines.includes('.bazelversion')) {
-      const cmd = `${bazel} query 'kind(".*_test rule", "...")'`;
+      const cmd = `${bazel} query 'kind("web_.* rule", "...")'`;
       const result = await exec(cmd, opts);
       const unfiltered = result.split('\n').filter(Boolean);
       const targets = unfiltered.filter(target => {
@@ -115,7 +115,7 @@ const findChangedBazelTargets = async ({root, files}) => {
         batches(queryables, 1000), // batching required, else E2BIG errors
         async q => {
           const innerQuery = q.join(' union ');
-          const cmd = `${bazel} query 'let graph = kind(".*_test rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;
+          const cmd = `${bazel} query 'let graph = kind("web_.* rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;
           return exec(cmd, opts);
         }
       );

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -78,7 +78,7 @@ const findChangedBazelTargets = async ({root, files}) => {
   const opts = {cwd: root, maxBuffer: 1e9};
   if (workspace === 'sandbox') {
     if (lines.includes('WORKSPACE') || lines.includes('.bazelversion')) {
-      const cmd = `${bazel} query 'kind("web_.* rule", "...")'`;
+      const cmd = `${bazel} query 'kind("(web_.*|.*_test) rule", "...")'`;
       const result = await exec(cmd, opts);
       const unfiltered = result.split('\n').filter(Boolean);
       const targets = unfiltered.filter(target => {
@@ -115,7 +115,7 @@ const findChangedBazelTargets = async ({root, files}) => {
         batches(queryables, 1000), // batching required, else E2BIG errors
         async q => {
           const innerQuery = q.join(' union ');
-          const cmd = `${bazel} query 'let graph = kind("web_.* rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;
+          const cmd = `${bazel} query 'let graph = kind("(web_.*|.*_test) rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;
           return exec(cmd, opts);
         }
       );


### PR DESCRIPTION
Jira: https://t3.uberinternal.com/browse/WPT-9167

Currently, `jz changes` with `--format targets` only returns `*_test` rules. This updates it to also include any `web_*` rules (e.g. `web_library`, `web_binary`, `web_executable`)