### PR TITLE
implement cmd_prefix hook

### DIFF
--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -71,7 +71,8 @@ else
 
   # payload
   export NODE_NO_WARNINGS=1 # hide [MODULE_NOT_FOUND] errors
-  "$NODE" --max_old_space_size=65536 "$JAZELLE" "$@"
+  CMD_PREFIX=$(eval "$("$NODE" -p "require('$ROOT/manifest.json').hooks.cmd_prefix || ''" 2>/dev/null || true)")
+  $CMD_PREFIX "$NODE" --max_old_space_size=65536 "$JAZELLE" "$@"
   EXIT_CODE=$?
 
   # postcommand hook


### PR DESCRIPTION
This hooks allows jazelle commands to be prefixed or wrapped.

Examples:

- always prefix an env var, 
```
// manifest.json
{
  "hooks": {
    "cmd_prefix": "echo 'FOO=1'"
  }
}
```

- always time commands
```
// manifest.json
{
  "hooks": {
    "cmd_prefix": "time"
  }
}
```

- always print command instead of running
```
// manifest.json
{
  "hooks": {
    "cmd_prefix": "echo 'echo'"
  }
}
```

Since the script is a shell script, it's also possible to conditionally prefix, etc