### PR TITLE
make prefix cwd correct in prefix hook even if a command is run from a non-root dir

### DIFF
--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -71,7 +71,7 @@ else
 
   # payload
   export NODE_NO_WARNINGS=1 # hide [MODULE_NOT_FOUND] errors
-  CMD_PREFIX=$(eval "$(cd "$ROOT" && "$NODE" -p "require('./manifest.json').hooks.cmd_prefix || ''" 2>/dev/null || true)")
+  CMD_PREFIX=$(cd "$ROOT" && eval "$("$NODE" -p "require('./manifest.json').hooks.cmd_prefix || ''" 2>/dev/null || true)")
   $CMD_PREFIX "$NODE" --max_old_space_size=65536 "$JAZELLE" "$@"
   EXIT_CODE=$?
 


### PR DESCRIPTION
make prefix hook cwd correct even if a command is run from a non-root dir