### PR TITLE
Ensure PnP ESM loader is used when available

### DIFF
--- a/rules/execute-command.js
+++ b/rules/execute-command.js
@@ -98,7 +98,7 @@ async function runCommand(command, args = []) {
   } else if (command.includes('${NODE}')) {
     // Support `build = "${NODE} ${ROOT_DIR}/foo.js"` as a web_binary build argument (instead of a package.json script name)
     const loaderPath = join(rootDir, '.pnp.loader.mjs');
-    const loaderArgs = exists(loaderPath) ? `` : `--loader '${loaderPath}'`;
+    const loaderArgs = exists(loaderPath) ? `--loader '${loaderPath}'` : '';
 
     const exe =
       process.env.NODE_SKIP_PNP === '1'


### PR DESCRIPTION
The logic to load the PnP ESM loader need to be reversed, as previously it would skip the loader if it's present on the filesystem 