### PR TITLE
Add missing darwin-arm64 entry

### DIFF
--- a/templates/scaffold/WORKSPACE
+++ b/templates/scaffold/WORKSPACE
@@ -9,6 +9,7 @@ load("@jazelle//:workspace-rules.bzl", "jazelle_dependencies")
 jazelle_dependencies(
   node_version = "NODE_VERSION",
   node_sha256 = {
+    "darwin-arm64": "",
     "darwin-x64": "",
     "linux-x64": "",
     "win-x64": "",


### PR DESCRIPTION
Fix #102 by adding the missing `darwin-arm64` entry in `WORKSPACE` template.