### PR TITLE
Handle special case of yarn v2 global script with bazel

### DIFF
--- a/tests/fixtures/bazel-rules/projects/b/package.json
+++ b/tests/fixtures/bazel-rules/projects/b/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "/bin/mkdir -p dist && cp index.js dist/index.js",
-    "dev": "node dist/index.js"
+    "dev": "node dist/index.js",
+    "uber-b:global-script": "echo hello from @uber/b"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -732,6 +732,13 @@ async function testBazelBuild() {
     name: 'test',
     stdio: ['ignore', runStream, 'ignore'],
   });
+  await bazelCmds.run({
+    root: `${tmp}/tmp/bazel-rules`,
+    cwd: `${tmp}/tmp/bazel-rules/projects/a`,
+    args: ['uber-b:global-script'],
+    name: 'script',
+    stdio: ['ignore', runStream, 'ignore'],
+  });
   await expectProcessExit(11, () =>
     bazelCmds.run({
       root: `${tmp}/tmp/bazel-rules`,
@@ -744,6 +751,7 @@ async function testBazelBuild() {
   const runData = await read(runStreamFile, 'utf8');
   assert(runData.includes('\nb\nv16.15.0'));
   assert(runData.includes('\nfoo exit'));
+  assert(runData.includes('\nhello from @uber/b'));
 
   // lint
   const lintStreamFile = `${tmp}/tmp/bazel-rules/lint-stream.txt`;


### PR DESCRIPTION
Handle special case of Yarn v2 global script when executing a bazelified script

 > Scripts containing `:` (the colon character) are globals to your project and can be called regardless of your current workspace. See https://yarnpkg.com/getting-started/qa#how-to-share-scripts-between-workspaces