### PR TITLE
Fixing json formatting for outdated command

### DIFF
--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -181,7 +181,7 @@ const outdated /*: Outdated */ = async ({
         : logger(entry.packageName, entry.installed.join(' '), entry.latest)
     );
     if (json) {
-      const closingBrace = ']' + (resultIndex < results.length - 1 ? ',': '');
+      const closingBrace = ']' + (resultIndex < results.length - 1 ? ',' : '');
       logger(closingBrace);
     }
   });

--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -157,7 +157,9 @@ const outdated /*: Outdated */ = async ({
   }
 
   // report discrepancies
-  for (const result of results) {
+  if (json) logger('[');
+
+  results.forEach((result, resultIndex) => {
     const formatted = [];
     if (dedup) {
       formatted.push(result);
@@ -178,8 +180,12 @@ const outdated /*: Outdated */ = async ({
           )
         : logger(entry.packageName, entry.installed.join(' '), entry.latest)
     );
-    if (json) logger(']');
-  }
+    if (json) {
+      const closingBrace = ']' + (resultIndex < results.length - 1 ? ',': '');
+      logger(closingBrace);
+    }
+  });
+  if (json) logger(']');
 };
 
 module.exports = {outdated};

--- a/commands/outdated.js
+++ b/commands/outdated.js
@@ -137,7 +137,8 @@ const outdated /*: Outdated */ = async ({
     (pckg /*: string */) => !getLocal(pckg)
   );
   let info /*: { [string]: { [string]: mixed } } */ = {};
-  for (const part of partition(externalPackages, limit)) {
+  const partitions = partition(externalPackages, limit);
+  for (const part of partitions) {
     Object.assign(info, await fetchInfo(part));
   }
 
@@ -172,18 +173,15 @@ const outdated /*: Outdated */ = async ({
       );
     }
 
-    if (json) logger('[');
-    formatted.forEach((entry, i) =>
-      json
-        ? logger(
-            JSON.stringify(entry) + (i !== formatted.length - 1 ? ',' : '')
-          )
-        : logger(entry.packageName, entry.installed.join(' '), entry.latest)
-    );
-    if (json) {
-      const closingBrace = ']' + (resultIndex < results.length - 1 ? ',' : '');
-      logger(closingBrace);
-    }
+    formatted.forEach((entry, i) => {
+      if (json) {
+        const needsComma =
+          i < formatted.length - 1 || resultIndex < results.length - 1;
+        logger(JSON.stringify(entry) + (needsComma ? ',' : ''));
+      } else {
+        logger(entry.packageName, entry.installed.join(' '), entry.latest);
+      }
+    });
   });
   if (json) logger(']');
 };

--- a/tests/fixtures/outdated/a/package.json
+++ b/tests/fixtures/outdated/a/package.json
@@ -2,6 +2,7 @@
   "name": "a",
   "dependencies": {
     "only-version-one-zero-zero": "0.1.0",
+    "semver": "^6.2.0",
     "@alexmsmithca/does-not-exist": "1.0.0"
   }
 }

--- a/tests/fixtures/outdated/b/package.json
+++ b/tests/fixtures/outdated/b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "a",
   "dependencies": {
-    "only-version-one-zero-zero": "0.2.0"
+    "only-version-one-zero-zero": "0.2.0",
+    "serialize-javascript": "^4.0.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -2374,7 +2374,7 @@ async function testOutdated() {
   // Test --json option w/out --dedup
   {
     await outdated({root, logger, json: true, dedup: false});
-    let parsed = []; /*: ?{[Object]: string} */
+    let parsed = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {
@@ -2420,7 +2420,7 @@ async function testOutdated() {
   {
     await outdated({root, logger, json: true, dedup: true});
 
-    let parsed = []; /*: ?{[Object]: string} */
+    let parsed = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2338,31 +2338,124 @@ async function testOutdated() {
 
   // Sanity check
   await outdated({root, logger});
+
+  // helper function to sort an array of objects by their
+  // 'packageName' property.
+  function packageNameCmpFunc(a, b) {
+    if (a.packageName < b.packageName) {
+      return -1;
+    } else if (a.packageName > b.packageName) {
+      return 1;
+    }
+    return 0;
+  }
+
+  data.sort();
   assert.equal(data[0], 'only-version-one-zero-zero 0.1.0 1.0.0');
   assert.equal(data[1], 'only-version-one-zero-zero 0.2.0 1.0.0');
+  assert.equal(data[2].substring(0, 'semver ^6.2.0 '.length), 'semver ^6.2.0 ');
+  assert.equal(
+    data[3].substring(0, 'serialize-javascript ^4.0.0 '.length),
+    'serialize-javascript ^4.0.0 '
+  );
   flush();
 
   // Test --dedup option
   await outdated({root, logger, dedup: true});
-  assert.equal(data.join(), 'only-version-one-zero-zero 0.1.0 0.2.0 1.0.0');
+  data.sort();
+  assert.equal(data[0], 'only-version-one-zero-zero 0.1.0 0.2.0 1.0.0');
+  assert.equal(data[1].substring(0, 'semver ^6.2.0 '.length), 'semver ^6.2.0 ');
+  assert.equal(
+    data[2].substring(0, 'serialize-javascript ^4.0.0 '.length),
+    'serialize-javascript ^4.0.0 '
+  );
   flush();
 
-  // Test --json option w/ --dedup
-  await outdated({root, logger, json: true, dedup: true});
-  let parsed /*: ?{[string]: string} */;
-  try {
-    parsed = JSON.parse(data.join(''));
-  } catch (e) {
-    // $FlowFixMe
-    assert.fail(`Unable to call JSON.parse on data: ${data.join('')}`);
+  // Test --json option w/out --dedup
+  {
+    await outdated({root, logger, json: true, dedup: false});
+    let parsed = []; /*: ?{[Object]: string} */
+    try {
+      parsed = JSON.parse(data.join(''));
+    } catch (e) {
+      // $FlowFixMe
+      assert.fail(`Unable to call JSON.parse on data: ${data.join('')}`);
+    }
+    assert.equal(parsed.length, 4);
+
+    // sort objects by package name, and over-write latest version of
+    // semver and serialize-javascript
+    parsed.sort(packageNameCmpFunc);
+    assert.equal(parsed[2].packageName, 'semver');
+    parsed[2]['latest'] = 'semver-latest';
+    assert.equal(parsed[3].packageName, 'serialize-javascript');
+    parsed[3]['latest'] = 'serialize-javascript-latest';
+
+    assert.deepEqual(parsed, [
+      {
+        packageName: 'only-version-one-zero-zero',
+        installed: ['0.1.0'],
+        latest: '1.0.0',
+      },
+      {
+        packageName: 'only-version-one-zero-zero',
+        installed: ['0.2.0'],
+        latest: '1.0.0',
+      },
+      {
+        packageName: 'semver',
+        installed: ['^6.2.0'],
+        latest: 'semver-latest',
+      },
+      {
+        packageName: 'serialize-javascript',
+        installed: ['^4.0.0'],
+        latest: 'serialize-javascript-latest',
+      },
+    ]);
+    flush();
   }
-  assert.deepEqual(parsed, [
-    {
-      packageName: 'only-version-one-zero-zero',
-      installed: ['0.1.0', '0.2.0'],
-      latest: '1.0.0',
-    },
-  ]);
+
+  // Test --json option w/ --dedup
+  {
+    await outdated({root, logger, json: true, dedup: true});
+
+    let parsed = []; /*: ?{[Object]: string} */
+    try {
+      parsed = JSON.parse(data.join(''));
+    } catch (e) {
+      // $FlowFixMe
+      assert.fail(`Unable to call JSON.parse on data: ${data.join('')}`);
+    }
+    assert.equal(parsed.length, 3);
+
+    // sort objects by package name, and over-write latest version of
+    // semver and serialize-javascript
+    parsed.sort(packageNameCmpFunc);
+    assert.equal(parsed[1].packageName, 'semver');
+    parsed[1]['latest'] = 'semver-latest';
+    assert.equal(parsed[2].packageName, 'serialize-javascript');
+    parsed[2]['latest'] = 'serialize-javascript-latest';
+
+    assert.deepEqual(parsed, [
+      {
+        packageName: 'only-version-one-zero-zero',
+        installed: ['0.1.0', '0.2.0'],
+        latest: '1.0.0',
+      },
+      {
+        packageName: 'semver',
+        installed: ['^6.2.0'],
+        latest: 'semver-latest',
+      },
+      {
+        packageName: 'serialize-javascript',
+        installed: ['^4.0.0'],
+        latest: 'serialize-javascript-latest',
+      },
+    ]);
+    flush();
+  }
 }
 
 async function testShouldInstall() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2374,7 +2374,7 @@ async function testOutdated() {
   // Test --json option w/out --dedup
   {
     await outdated({root, logger, json: true, dedup: false});
-    let parsed = [];
+    let parsed /*: Array<Object> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {
@@ -2420,7 +2420,7 @@ async function testOutdated() {
   {
     await outdated({root, logger, json: true, dedup: true});
 
-    let parsed = [];
+    let parsed /*: Array<Object> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -2374,7 +2374,7 @@ async function testOutdated() {
   // Test --json option w/out --dedup
   {
     await outdated({root, logger, json: true, dedup: false});
-    let parsed /*: Array<Object> */ = [];
+    let parsed /*: Array<{[string]: string}> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {
@@ -2420,7 +2420,7 @@ async function testOutdated() {
   {
     await outdated({root, logger, json: true, dedup: true});
 
-    let parsed /*: Array<Object> */ = [];
+    let parsed /*: Array<{[string]: string}> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
     } catch (e) {


### PR DESCRIPTION
Change json format of `outdated` command so there is an array of objects.  Previously, it would output an array of arrays of objects and it wasn't valid json. 

Also, added updated test case to validate json formatting problem is resolved. 