### PR TITLE
Vbump to version 81

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.80",
+  "version": "0.0.0-standalone.81",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",


### PR DESCRIPTION
Changes since version 80 vbump:
```
(71accbb) Fixing json formatting for outdated command (#123) (Mike Kaufman)
(a7b542f) Sort BUILD.bazel file deps on install (#124) (Leo Horie)
(59e2e11) update error message (#121) (Leo Horie)
(b2e5611) Add missing darwin-arm64 entry (#118) (Salvatore Gentile)
(6c06235) v0.0.0-standalone.80 (#120) (shYkiSto)
```