### PR TITLE
Sort files & directories before running copy

### DIFF
--- a/rules/untar.js
+++ b/rules/untar.js
@@ -46,7 +46,7 @@ function untarIntoSandbox(file) {
 function copyToSourceFolder(file) {
   const target = resolve(root, dirname(file));
   const real = dirname(realpath(`${target}/package.json`));
-  const files = exec(`tar ztf ${file}`, {encoding: 'utf8'})
+  const files = exec(`tar ztf ${file} | sort`, {encoding: 'utf8'})
     .trim()
     .split('\n')
     .map(line => line.replace(/\/$/, ''));


### PR DESCRIPTION
Files & folders can be added in any order for the tar command. And when you read the contents back using `tar ztf`, it returns the output in the order the files were added. This means you can end in cases where it lists a child folder before the parent.

i.e. you can have a `tar ztf` command that returns:
```
src/__gen__/foo/
src/__gen__/
```

With the current untar approach, it will try to create the foo folder and fail, because the `__gen__` folder needs to be created first.

Adding a sort to the end of it will make sure it returns
```
src/__gen__/
src/__gen__/foo/
```

That way the mkdir for `__gen__` is ran before `src/__gen__/foo/` and both directories are created.