### PR TITLE
Sort paths before generating tar.gz files from execute-command

### DIFF
--- a/rules/untar.js
+++ b/rules/untar.js
@@ -55,12 +55,14 @@ function copyToSourceFolder(file) {
   }
 }
 
-function copy(target, real, file) {
+function copy(target /*: string */, real /*: string */, file /*: string */) {
   const targetPath = `${target}/${file}`;
   if (!exists(targetPath)) return;
   if (stat(targetPath).isDirectory()) {
     const srcPath = `${real}/${file}`;
-    if (!exists(srcPath)) mkdir(srcPath);
+    if (!exists(srcPath)) {
+      mkdir(srcPath, {recursive: true});
+    }
     for (const child of ls(srcPath)) {
       copy(target, real, `${file}/${child}`);
     }
@@ -70,7 +72,7 @@ function copy(target, real, file) {
       const srcPath = `${real}/${file}`;
       const srcDir = dirname(srcPath);
       if (!exists(srcDir)) {
-        mkdir(srcDir);
+        mkdir(srcDir, {recursive: true});
       }
       cp(`${target}/${file}`, `${real}/${file}`);
     }
@@ -84,3 +86,5 @@ function read(file) {
     return Symbol('not found'); // must return something that does not equal itself
   }
 }
+
+module.exports = {copy};


### PR DESCRIPTION
Without the patch:
File order usually doesn't matter when you create archives, but Jazelle uses the `tar ztf ${file}` command here https://github.com/uber-web/jazelle/blob/main/rules/untar.js#L49 which returns files in the order they were added to the archive and assumes that parent folders are before child folders.

This can result in errors because it tries to create a child directory before the parent directory.

i.e.
```
src/__gen__/foo/
src/__gen__/
```

When the untar copyToSourceFolder command runs it will result in the error:

`Error: ENOENT: no such file or directory, mkdir '...../src/__gen__/foo`

With the patch:
Changing the mkdir to create recursive files means the tar can be in any order and it will still work. 