### PR TITLE
Simplify add/upgrade

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -88,7 +88,16 @@ const add /*: Add */ = async ({root, cwd, args, dev = false}) => {
     const options = {cwd: root, stdio: 'inherit'};
     await spawn(
       node,
-      [yarn, 'workspace', meta.name, 'add', '--mode', 'skip-build', ...keys, ...flags],
+      [
+        yarn,
+        'workspace',
+        meta.name,
+        'add',
+        '--mode',
+        'skip-build',
+        ...keys,
+        ...flags,
+      ],
       options
     );
     // reload package.json affected by workspace add command

--- a/commands/add.js
+++ b/commands/add.js
@@ -88,18 +88,13 @@ const add /*: Add */ = async ({root, cwd, args, dev = false}) => {
     const options = {cwd: root, stdio: 'inherit'};
     await spawn(
       node,
-      [yarn, 'workspace', meta.name, 'add', ...keys, ...flags],
+      [yarn, 'workspace', meta.name, 'add', '--mode', 'skip-build', ...keys, ...flags],
       options
     );
     // reload package.json affected by workspace add command
     const allDeps = /*:: await */ await getAllDependencies({root, projects});
     const dep = allDeps.find(item => item.dir === cwd);
     if (dep) dep.meta = JSON.parse(await read(`${cwd}/package.json`));
-    await spawn(node, [yarn, 'install', '--mode', 'update-lockfile'], {
-      cwd: root,
-      stdio: 'ignore',
-      detached: true,
-    });
 
     const deps = /*:: await */ await getLocalDependencies({
       data: allDeps,

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -14,7 +14,6 @@ export type UpgradeArgs = {
 export type Upgrade = (UpgradeArgs) => Promise<void>;
 */
 const upgrade /*: Upgrade */ = async ({root, args}) => {
-  console.log(123)
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -14,6 +14,7 @@ export type UpgradeArgs = {
 export type Upgrade = (UpgradeArgs) => Promise<void>;
 */
 const upgrade /*: Upgrade */ = async ({root, args}) => {
+  console.log(123)
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 
@@ -55,7 +56,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
     const deps = externals.map(({name, range}) => {
       return name + (range ? `@${range}` : '');
     });
-    await spawn(node, [yarn, 'up', '-C', ...deps], {
+    await spawn(node, [yarn, 'up', '-C', ...deps, '--mode', 'skip-build'], {
       cwd: root,
       stdio: 'inherit',
     });


### PR DESCRIPTION
Follow up to #132, makes these commands run even faster by avoiding built-in build steps