### PR TITLE
Adds a 'typecheck' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ If you get into a bad state, here are some things you can try:
 - [`jazelle test`](#jazelle-test)
 - [`jazelle lint`](#jazelle-lint)
 - [`jazelle flow`](#jazelle-flow)
+- [`jazelle typecheck`](#jazelle-typecheck)
 - [`jazelle start`](#jazelle-start)
 - [`jazelle script`](#jazelle-script)
 - [`jazelle bazel`](#jazelle-bazel)
@@ -623,12 +624,21 @@ Lints a project. Calls `scripts.lint` in package.json
 
 ### `jazelle flow`
 
-Type-checks a project. Calls `scripts.flow` in package.json
+Type-checks a project using FlowType. Calls `scripts.flow` in package.json
 
 `jazelle flow --cwd [cwd] [args...]`
 
 - `--cwd` - Project folder (absolute or relative to shell `cwd`). Defaults to `process.cwd()`
 - `args` - A space separated list of arguments to pass to the flow script
+
+### `jazelle typecheck`
+
+Type-checks a project. Calls `scripts.typecheck` in package.json
+
+`jazelle typecheck --cwd [cwd] [args...]`
+
+- `--cwd` - Project folder (absolute or relative to shell `cwd`). Defaults to `process.cwd()`
+- `args` - A space separated list of arguments to pass to the typecheck script (e.g. `tsc`)
 
 ### `jazelle start`
 

--- a/commands/typecheck.js
+++ b/commands/typecheck.js
@@ -15,7 +15,6 @@ export type TypecheckArgs = {
 export type Typecheck = (TypecheckArgs) => Promise<void>
 */
 const typecheck /*: Typecheck */ = async ({root, cwd, args, stdio = 'inherit'}) => {
-  console.log("ARGS", args);
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);

--- a/commands/typecheck.js
+++ b/commands/typecheck.js
@@ -14,7 +14,12 @@ export type TypecheckArgs = {
 }
 export type Typecheck = (TypecheckArgs) => Promise<void>
 */
-const typecheck /*: Typecheck */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const typecheck /*: Typecheck */ = async ({
+  root,
+  cwd,
+  args,
+  stdio = 'inherit',
+}) => {
   await assertProjectDir({dir: cwd});
 
   const params = getPassThroughArgs(args);

--- a/commands/typecheck.js
+++ b/commands/typecheck.js
@@ -1,0 +1,31 @@
+// @flow
+
+const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {getPassThroughArgs} = require('../utils/parse-argv.js');
+const {executeProjectCommand} = require('../utils/execute-project-command.js');
+
+/*::
+import type {Stdio} from '../utils/node-helpers.js';
+export type TypecheckArgs = {
+  root: string,
+  cwd: string,
+  args: Array<string>,
+  stdio?: Stdio,
+}
+export type Typecheck = (TypecheckArgs) => Promise<void>
+*/
+const typecheck /*: Typecheck */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+  console.log("ARGS", args);
+  await assertProjectDir({dir: cwd});
+
+  const params = getPassThroughArgs(args);
+  await executeProjectCommand({
+    root,
+    cwd,
+    command: 'typecheck',
+    args: params,
+    stdio,
+  });
+};
+
+module.exports = {typecheck};

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const {dev} = require('./commands/dev.js');
 const {test} = require('./commands/test.js');
 const {lint} = require('./commands/lint.js');
 const {flow} = require('./commands/flow.js');
+const {typecheck} = require('./commands/typecheck.js');
 const {start} = require('./commands/start.js');
 const {node} = require('./commands/node.js');
 const {yarn} = require('./commands/yarn.js');
@@ -265,10 +266,16 @@ const runCLI /*: RunCLI */ = async argv => {
         async ({cwd}) => lint({root: await rootOf(args), cwd, args: rest}),
       ],
       flow: [
-        `Typecheck a project
+        `Typecheck a project using FlowType
 
         --cwd [cwd]                Project directory to use`,
         async ({cwd}) => flow({root: await rootOf(args), cwd, args: rest}),
+      ],
+      typecheck: [
+        `Typecheck a project
+
+        --cwd [cwd]                Project directory to use`,
+        async ({cwd}) => typecheck({root: await rootOf(args), cwd, args: rest}),
       ],
       start: [
         `Run a project

--- a/utils/bazel-commands.js
+++ b/utils/bazel-commands.js
@@ -146,6 +146,19 @@ const flow /*: Flow */ = async ({root, cwd, args, stdio = 'inherit'}) => {
 };
 
 /*::
+export type TypecheckArgs = {
+  root: string,
+  cwd: string,
+  args: Array<string>,
+  stdio?: Stdio,
+};
+type Typecheck = (TypecheckArgs) => Promise<void>;
+*/
+const typecheck /*: Typecheck */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+  await run({root, cwd, args, name: 'typecheck', stdio});
+};
+
+/*::
 export type StartArgs = {
   root: string,
   cwd: string,
@@ -205,6 +218,7 @@ module.exports = {
   test,
   lint,
   flow,
+  typecheck,
   dev,
   start,
   run,

--- a/utils/bazel-commands.js
+++ b/utils/bazel-commands.js
@@ -154,7 +154,12 @@ export type TypecheckArgs = {
 };
 type Typecheck = (TypecheckArgs) => Promise<void>;
 */
-const typecheck /*: Typecheck */ = async ({root, cwd, args, stdio = 'inherit'}) => {
+const typecheck /*: Typecheck */ = async ({
+  root,
+  cwd,
+  args,
+  stdio = 'inherit',
+}) => {
   await run({root, cwd, args, name: 'typecheck', stdio});
 };
 

--- a/utils/execute-project-command.js
+++ b/utils/execute-project-command.js
@@ -33,6 +33,8 @@ const executeProjectCommand /*: ExecuteProjectCommand */ = async ({
         return bazel.lint({root, cwd, args, stdio});
       case 'flow':
         return bazel.flow({root, cwd, args, stdio});
+      case 'typecheck':
+        return bazel.typecheck({root, cwd, args, stdio});
       case 'build':
         return bazel.build({root, cwd});
       case 'start':
@@ -58,6 +60,8 @@ const executeProjectCommand /*: ExecuteProjectCommand */ = async ({
         return yarn.lint({root, deps, args, stdio});
       case 'flow':
         return yarn.flow({root, deps, args, stdio});
+      case 'typecheck':
+        return yarn.typecheck({root, deps, args, stdio});
       case 'build':
         return yarn.build({root, deps});
       case 'start':

--- a/utils/yarn-commands.js
+++ b/utils/yarn-commands.js
@@ -141,6 +141,25 @@ const flow /*: Flow */ = async ({root, deps, args, stdio = 'inherit'}) => {
 };
 
 /*::
+export type TypecheckArgs = {
+  root: string,
+  deps: Array<Metadata>,
+  args: Array<string>,
+  stdio?: Stdio,
+};
+export type Typecheck = (TypecheckArgs) => Promise<void>;
+*/
+const typecheck /*: Typecheck */ = async ({root, deps, args, stdio = 'inherit'}) => {
+  const main = deps.slice(-1).pop();
+  await batchBuild({root, deps, self: false, stdio: errorsOnly});
+  await spawnOrExit(node, [yarn, 'typecheck', ...args], {
+    stdio,
+    env: {...process.env},
+    cwd: main.dir,
+  });
+};
+
+/*::
 export type StartArgs = {
   root: string,
   deps: Array<Metadata>,
@@ -205,4 +224,4 @@ const script /*: Script */ = async ({
   });
 };
 
-module.exports = {build, test, lint, flow, dev, start, exec, script};
+module.exports = {build, test, lint, flow, typecheck, dev, start, exec, script};

--- a/utils/yarn-commands.js
+++ b/utils/yarn-commands.js
@@ -149,7 +149,12 @@ export type TypecheckArgs = {
 };
 export type Typecheck = (TypecheckArgs) => Promise<void>;
 */
-const typecheck /*: Typecheck */ = async ({root, deps, args, stdio = 'inherit'}) => {
+const typecheck /*: Typecheck */ = async ({
+  root,
+  deps,
+  args,
+  stdio = 'inherit',
+}) => {
   const main = deps.slice(-1).pop();
   await batchBuild({root, deps, self: false, stdio: errorsOnly});
   await spawnOrExit(node, [yarn, 'typecheck', ...args], {


### PR DESCRIPTION
Adds a new `typecheck` command.  Allows a consumer to declare a new rule with this name that can be invoked with `jz typecheck`.

```
_web_executable(
  name = "typecheck",
  command = "typecheck",
  preserve_symlinks = "",
  # depends on codegen via `:library`
  deps = ["{}:library".format(package), "{}:generate-tsconfig-references".format(package)],
)
```

Without these changes, the equivalent command folks would run is:

```
jz bazel run "<PATH_TO_PROJECT>:typecheck"
```

Running `jz typecheck` without it explicitly defined in Jazelle as it is here would proxy to the Yarn script which would not include running the respective `:library` or `generate-tsconfig-references` targets from the example above.