### PR TITLE
Fix supply chain vuln in test

### DIFF
--- a/tests/fixtures/bump/not-a-real-dep/package.json
+++ b/tests/fixtures/bump/not-a-real-dep/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "not-a-real-dep",
+  "name": "@uber/not-a-real-dep",
   "version": "0.0.0"
 }

--- a/tests/fixtures/bump/not-a-real-downstream/package.json
+++ b/tests/fixtures/bump/not-a-real-downstream/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "not-a-real-downstream",
+  "name": "@uber/not-a-real-downstream",
   "version": "0.0.0",
   "dependencies": {
-    "not-a-real-project": "0.0.0"
+    "@uber/not-a-real-project": "0.0.0"
   }
 }

--- a/tests/fixtures/bump/not-a-real-project/package.json
+++ b/tests/fixtures/bump/not-a-real-project/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "not-a-real-project",
+  "name": "@uber/not-a-real-project",
   "version": "0.0.0",
   "dependencies": {
-    "not-a-real-dep": "0.0.0"
+    "@uber/not-a-real-dep": "0.0.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -535,7 +535,7 @@ async function testBump() {
 
   // downstream is greenkept
   const meta = JSON.parse(await read(downstreamMeta));
-  assert.equal(meta.dependencies['not-a-real-project'], '0.1.0-0');
+  assert.equal(meta.dependencies['@uber/not-a-real-project'], '0.1.0-0');
   assert.equal(meta.version, '0.1.0-0');
 }
 


### PR DESCRIPTION
Currently test references a unnamespaced package. Changing to the @uber namespace to avoid dependency confusion attacks