### PR TITLE
Updating the update cmd to add workspace:* for internal upgrade

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -17,6 +17,12 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 
+  if (!args.length) {
+    throw new Error(
+      'Command must have at least one dependency name. \nUsage: jazelle upgrade [dependency]\n'
+    );
+  }
+
   // group by whether the dep is local (listed in manifest.json) or external (from registry)
   const locals = [];
   const externals = [];
@@ -38,10 +44,12 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
             throw new Error(error);
           }
 
+          const localVersion = 'workspace:*';
+
           // don't update peerDependencies, we don't want to inadvertedly cause downstreams to have multiple versions of things
-          update(meta, 'dependencies', name, local.meta.version);
-          update(meta, 'devDependencies', name, local.meta.version);
-          update(meta, 'optionalDependencies', name, local.meta.version);
+          update(meta, 'dependencies', name, localVersion);
+          update(meta, 'devDependencies', name, localVersion);
+          update(meta, 'optionalDependencies', name, localVersion);
         }
         await write(
           `${cwd}/package.json`,

--- a/tests/index.js
+++ b/tests/index.js
@@ -373,11 +373,14 @@ async function testFocus() {
 }
 
 async function testUpgrade() {
+  const errorMessage =
+    'Command must have at least one dependency name. \nUsage: jazelle upgrade [dependency]\n';
   const meta = `${tmp}/tmp/upgrade/a/package.json`;
   const lockfile = `${tmp}/tmp/upgrade/yarn.lock`;
   const cmd = `cp -r ${__dirname}/fixtures/upgrade/ ${tmp}/tmp/upgrade`;
   await exec(cmd);
 
+  // external upgrade
   await upgrade({
     root: `${tmp}/tmp/upgrade`,
     args: ['has@1.0.3'],
@@ -385,8 +388,17 @@ async function testUpgrade() {
   assert((await read(meta, 'utf8')).includes('"has": "1.0.3"'));
   assert((await read(lockfile, 'utf8')).includes('function-bind'));
 
+  // internal upgrade
   await upgrade({root: `${tmp}/tmp/upgrade`, args: ['b']});
-  assert((await read(meta, 'utf8')).includes('"b": "1.0.0"'));
+  assert((await read(meta, 'utf8')).includes('"b": "workspace:*"'));
+
+  // missing dependency
+  try {
+    await upgrade({root: `${tmp}/tmp/upgrade`, args: []});
+  } catch (e) {
+    // $FlowFixMe
+    assert(e.message.includes(errorMessage));
+  }
 }
 
 async function testPurge() {
@@ -535,7 +547,7 @@ async function testBump() {
 
   // downstream is greenkept
   const meta = JSON.parse(await read(downstreamMeta));
-  assert.equal(meta.dependencies['@uber/not-a-real-project'], '0.1.0-0');
+  assert.equal(meta.dependencies['@uber/not-a-real-project'], 'workspace:*');
   assert.equal(meta.version, '0.1.0-0');
 }
 

--- a/utils/report-mismatched-top-level-deps.js
+++ b/utils/report-mismatched-top-level-deps.js
@@ -79,7 +79,7 @@ export type GetErrorMessage = (Report, boolean) => string;
 const getErrorMessage /*: GetErrorMessage */ = (result, json = false) => {
   if (!result.valid) {
     const message = red(
-      `Version policy violation. Use \`jazelle upgrade\` to ensure all projects use the same dependency version`
+      `Version policy violation. Use \`jazelle upgrade [dependency]\` to ensure all projects use the same dependency version`
     );
     const report = JSON.stringify(result.reported, null, 2);
     let violations = `\nViolations:\n${report}`;


### PR DESCRIPTION
- When upgrading internal dependencies, we are using workspace:* instead of the version specified in the package.json for that dependency
- We are now educating the user on the usage of the `jazelle upgrade` if they are not including the dependency in the upgrade command
- The mismatch version error message now shows the correct usage for the jazelle upgrade command