### PR TITLE
Add custom mnemonic to WebBinary rule

### DIFF
--- a/rules/web-monorepo.bzl
+++ b/rules/web-monorepo.bzl
@@ -73,6 +73,7 @@ def _web_binary_impl(ctx):
   )
 
   ctx.actions.run_shell(
+    mnemonic = ctx.attr.mnemonic,
     command = """
     export NODE_PRESERVE_SYMLINKS='{preserve_symlinks}';
     export CWD=$(cd `dirname '{srcdir}'` && pwd);
@@ -144,11 +145,15 @@ web_binary = rule(
     "skip_pnp": attr.bool(
       default = False,
     ),
+    "mnemonic": attr.string(
+      default = "WebBinary",
+      doc = "Custom one-word name of the rule",
+    ),
   },
   executable = True,
   outputs = {
     "out": "__jazelle__%{name}.tgz"
-  },
+  }
 )
 
 def _web_executable_impl(ctx):


### PR DESCRIPTION
WebBinary is used like a wrapper for different actions, including code generation. Allow it to accept a custom action name to differentiate easier for profiling / monitoring.