### PR TITLE
Reduce bazel query batch size to avoid E2BIG errors in large changesets

### DIFF
--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -112,7 +112,7 @@ const findChangedBazelTargets = async ({root, files}) => {
       const queryables = [...exists, ...recoveredMissing];
       const unfiltered = await batch(
         root,
-        batches(queryables, 1000), // batching required, else E2BIG errors
+        batches(queryables, 500), // batching required, else E2BIG errors
         async q => {
           const innerQuery = q.join(' union ');
           const cmd = `${bazel} query 'let graph = kind("(web_.*|.*_test|filegroup) rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;


### PR DESCRIPTION
I'm working on a diff that includes a couple thought changed files and `jazelle changes` throws a `E2BIG` error. Assuming this will resolve the issue, but I'm not familiar with how to test this branch with my local repo