### PR TITLE
add keep_going flag to changed-targets query

### DIFF
--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -115,7 +115,7 @@ const findChangedBazelTargets = async ({root, files}) => {
         batches(queryables, 1000), // batching required, else E2BIG errors
         async q => {
           const innerQuery = q.join(' union ');
-          const cmd = `${bazel} query 'let graph = kind("(web_.*|.*_test|filegroup) rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label`;
+          const cmd = `${bazel} query 'let graph = kind("(web_.*|.*_test|filegroup) rule", rdeps("...", ${innerQuery})) in $graph except filter("node_modules", $graph)' --output label --keep_going`;
           return exec(cmd, opts);
         }
       );


### PR DESCRIPTION
`jazelle changes` requires changed files to be source file targets but I think this is an unnecessary constraint. Consider some arbitrary file like `README.md` which conceivably has no impact on builds, but will be updated often. I chose to add the `--keep_going` flag to ignore errors like below, but maybe there is a better way check early and exclude this class of file?

`Skipping 'src/a/README.md': no such target '//src/a:README.md': target 'README.md' not declared in package 'src/a' defined by /.../src/a/BUILD.bazel; however, a source file of this name exists.  (Perhaps add 'exports_files(["README.md"])' to src/a/BUILD?)`