### PR TITLE
handle non-zero exit code in jazelle changes bazel query

### DIFF
--- a/tests/fixtures/find-changed-targets/bazel/changes.txt
+++ b/tests/fixtures/find-changed-targets/bazel/changes.txt
@@ -1,3 +1,4 @@
 b/package.json
 non-jazelle/BUILD.bazel
 non-js/x.txt
+non-js/z.txt

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -75,7 +75,7 @@ const findChangedBazelTargets = async ({root, files}) => {
   if (invalid) throw new Error(`File path cannot contain spaces: ${invalid}`);
 
   const {projects, workspace} = await getManifest({root});
-  const opts = {cwd: root, maxBuffer: 1e9};
+  const opts = {cwd: root, keepGoing: true, maxBuffer: 1e9};
   if (workspace === 'sandbox') {
     if (lines.includes('WORKSPACE') || lines.includes('.bazelversion')) {
       const cmd = `${bazel} query 'kind("(web_.*|.*_test) rule", "...")'`;

--- a/utils/node-helpers.js
+++ b/utils/node-helpers.js
@@ -89,7 +89,7 @@ const exec /*: Exec */ = (cmd, opts = {}, stdio = []) => {
     const child = proc.exec(cmd, opts, (err, stdout, stderr) => {
       removeActiveChild(child);
 
-      if (err) {
+      if (err && !opts.keepGoing) {
         // $FlowFixMe
         errorWithSyncStackTrace.status = err.code;
         errorWithSyncStackTrace.message = err.message;


### PR DESCRIPTION
Because of how the `exec` fn in `node-helpers.js` is constructed, if the cmd returns with a non-zero exit code the stdout will not be returned. This does not play nicely with the previous change I made https://github.com/uber-web/jazelle/pull/147 where we can 'keep going' if changed files are not inputs to any bezel targets. In the previous PR I neglected to add a regression test for the behavior, and now following up with a test and fix.