### PR TITLE
Make sure bazel info messages are logged to stderr

### DIFF
--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -50,8 +50,10 @@ else
     # if we're in a repo, jazelle declaration in WORKSPACE is wrong, so we should error out
     if [ -f "$ROOT/WORKSPACE" ]
     then
-      cat /tmp/jazelle.log 2>/dev/null # logged by bootstrap.sh
-      echo "Attempting to use system Node/Yarn/Jazelle versions..."
+      # bazel info messages go to stderr; discarding any errors from cat,
+      # e.g., if log file does not exist
+      cat /tmp/jazelle.log >&2 2>/dev/null # logged by bootstrap.sh
+      echo "Attempting to use system Node/Yarn/Jazelle versions..." >&2
     fi
     NODE="$(which node)"
     YARN="$BIN/yarn.js"


### PR DESCRIPTION
Conventionally bazel writes all of its info / system messages to `stderr`, preserving the `stdout` for the script / build output itself. Today, jazelle will write bazel logs collected during bootstrap to stdout polluting the standard output that may lead to unexpected behavior in user scripts, e.g., resolving a node binary via `jz bin-path node` may contain some junk breaking command substitution in scripts like this:
```bash
#!/bin/bash

NODE_PATH=$(jz bin-path node)
TEST=$($NODE_PATH -p "123") # this may throw command not found, if `jz bin-path node` output is polluted with other log messages
```