### PR TITLE
Bump version to 0.0.0-standalone.92

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.91",
+  "version": "0.0.0-standalone.92",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",


### PR DESCRIPTION
This includes following changes:
* https://github.com/uber-web/jazelle/pull/155