### PR TITLE
Optimize bazel target change detection and query execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.92",
+  "version": "0.0.0-standalone.93",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",


### PR DESCRIPTION
Optimize Bazel target change detection and query execution:
* Introduce a `bazelQuery` utility function to handle Bazel queries using a temporary file, avoiding issues with command argument length limitations
* Refactor `findChangedBazelTargets` to utilize the new `bazelQuery` function
  * Reduce the number of required queries to handle deleted files by querying all file labels in a single query using `--keep_going` option. Also, include all related source files instead of a single file to ensure we capture all of the package upstreams
  * Remove unnecessary batching logic and clean up code
