### PR TITLE
Use all modified files when calculating changed targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.93",
+  "version": "0.0.0-standalone.94",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -1,5 +1,4 @@
 // @flow
-const {dirname} = require('path');
 const {bazelQuery} = require('./bazel-commands.js');
 const {getManifest} = require('./get-manifest.js');
 const {getDownstreams} = require('../utils/get-downstreams.js');
@@ -82,8 +81,7 @@ const findChangedBazelTargets = async ({root, files}) => {
         Separate files into two categories: files that exist and files that have been deleted
         For files that have been deleted, try to recover some other file in the package
       */
-      const representatives = getTargetRepresentatives(lines);
-      const [missing, exists] = await scan(root, representatives);
+      const [missing, exists] = await scan(root, lines);
       const recoveredMissing = missing.length
         ? await bazelQuery({
             cwd: root,
@@ -108,7 +106,9 @@ const findChangedBazelTargets = async ({root, files}) => {
                 .filter(Boolean);
             })
         : [];
-      const innerQuery = [...exists, ...recoveredMissing].join(' + ');
+      const innerQuery = Array.from(
+        new Set([...exists, ...recoveredMissing])
+      ).join(' + ');
       const unfiltered = innerQuery.length
         ? (
             await bazelQuery({
@@ -180,27 +180,6 @@ const findChangedBazelTargets = async ({root, files}) => {
       return {workspace, targets};
     }
   }
-};
-
-// Optimization: For each folder, we typically only need to check one file,
-// since all files will generally map to the same target
-// given how jazelle generates BUILD.bazel files
-// However, this is only true of js files
-// For other types of targets, we need to be conservative and keep the entire list of files
-const getTargetRepresentatives = files => {
-  const map = new Map();
-  for (const file of files) {
-    const dir = dirname(file);
-    const list = map.get(dir) || map.set(dir, []).get(dir);
-    if (file.match(/(.jsx?|.tsx?)$/)) {
-      map.set(dir, [file]);
-    } else {
-      // $FlowFixMe
-      list.push(file);
-    }
-  }
-  // $FlowFixMe
-  return [...map.values()].flat();
 };
 
 module.exports = {findChangedTargets};

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -42,6 +42,10 @@ const scan = async (root, lines) => {
   ];
 };
 
+function quoteFilePaths(paths) {
+  return paths.map(path => `'${path}'`);
+}
+
 const findChangedBazelTargets = async ({root, files}) => {
   const bazelignore = await read(`${root}/.bazelignore`, 'utf8').catch(
     () => ''
@@ -85,7 +89,7 @@ const findChangedBazelTargets = async ({root, files}) => {
       const recoveredMissing = missing.length
         ? await bazelQuery({
             cwd: root,
-            query: missing.join(' + '),
+            query: quoteFilePaths(missing).join(' + '),
             args: ['--keep_going'],
           })
             .then(() => {
@@ -107,7 +111,7 @@ const findChangedBazelTargets = async ({root, files}) => {
             })
         : [];
       const innerQuery = Array.from(
-        new Set([...exists, ...recoveredMissing])
+        new Set([...quoteFilePaths(exists), ...recoveredMissing])
       ).join(' + ');
       const unfiltered = innerQuery.length
         ? (

--- a/utils/find-changed-targets.js
+++ b/utils/find-changed-targets.js
@@ -43,7 +43,7 @@ const scan = async (root, lines) => {
 };
 
 function quoteFilePaths(paths) {
-  return paths.map(path => `'${path}'`);
+  return paths.map(path => `"${path}"`);
 }
 
 const findChangedBazelTargets = async ({root, files}) => {
@@ -64,8 +64,17 @@ const findChangedBazelTargets = async ({root, files}) => {
     .map(line => line.trim())
     .filter(line => !ignored.find(i => line.startsWith(i)));
 
-  const invalid = lines.find(line => line.includes(' '));
-  if (invalid) throw new Error(`File path cannot contain spaces: ${invalid}`);
+  const invalid = lines.find(line => line.includes('"'));
+  if (invalid) {
+    // Disallow double quote (") character in file paths, because Bazel query syntax
+    // utilizes double quotes to encapsulate strings. Including a double quote within
+    // a file path could lead to syntax errors in the Bazel query.
+    // Note: In the future, we may relax this constraint if support is required. This could
+    // be achieved by running multiple queries, where file paths containing special characters
+    // like single or double quotes could be queried separately. File paths with single quotes
+    // could be encapsulated using double quotes, and vice versa, to ensure query integrity.
+    throw new Error(`File path cannot contain double quotes: '${invalid}'`);
+  }
 
   const {projects, workspace} = await getManifest({root});
   if (workspace === 'sandbox') {
@@ -105,7 +114,7 @@ const findChangedBazelTargets = async ({root, files}) => {
               const regex = /not declared in package '(.*?)'/g;
               return Array.from(e.message.matchAll(regex))
                 .map(([, pkg]) =>
-                  pkg ? `kind("source file", //${pkg}:*)` : ''
+                  pkg ? `kind("source file", "//${pkg}:*")` : ''
                 )
                 .filter(Boolean);
             })


### PR DESCRIPTION
Remove an optimization logic from the findChangedTargets function. This optimization was originally designed to reduce query size by considering only one JS/TS file per directory, based on the assumption that all source files in a directory would map to the same target. However, this assumption does not hold when working with more granular targets, necessitating the retention of all files to calculate changed targets more accurately.

By removing this optimization, we ensure correct file handling for all types of files and targets. The query size limitation is no longer a concern since we switched to using query files. Despite the removal, there is no significant speed regression observed in our monorepo containing hundreds of thousands of files. Essentially, we are trading speed for correctness.

Also, wrap file paths in quotes to handle special characters in bazel query, disallowing double quotes (") in file paths (we may relax this constraint in the future if support is required)

```
% time jz bazel query 'kind("source file", //...:*)' --output=label | sed 's|^//||; s|:|/|' | jz changes > /dev/null
# Before
jz changes 3.56s user 2.42s system 48% cpu 12.289 total

# After
jz changes 6.10s user 4.67s system 65% cpu 16.531 total
```