### PR TITLE
Handle missing files referenced in build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.94",
+  "version": "0.0.0-standalone.95",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",

--- a/tests/fixtures/find-changed-targets/bazel/changes-missing-files-label-only.txt
+++ b/tests/fixtures/find-changed-targets/bazel/changes-missing-files-label-only.txt
@@ -1,0 +1,1 @@
+test-missing-file-label-only-dep/missing-file-label.js

--- a/tests/fixtures/find-changed-targets/bazel/changes-missing-files.txt
+++ b/tests/fixtures/find-changed-targets/bazel/changes-missing-files.txt
@@ -1,0 +1,2 @@
+test-missing-file-dep/some-missing-file.js
+test-missing-file-label-only-dep/missing-file-label.js

--- a/tests/fixtures/find-changed-targets/bazel/package.json
+++ b/tests/fixtures/find-changed-targets/bazel/package.json
@@ -4,6 +4,10 @@
     "a",
     "b",
     "c",
-    "d"
+    "d",
+    "test-missing-file",
+    "test-missing-file-dep",
+    "test-missing-file-label-only",
+    "test-missing-file-label-only-dep"
   ]
 }

--- a/tests/fixtures/find-changed-targets/bazel/test-missing-file-dep/package.json
+++ b/tests/fixtures/find-changed-targets/bazel/test-missing-file-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-missing-file-dep",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only-dep/BUILD.bazel
+++ b/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only-dep/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@jazelle//:build-rules.bzl", "web_library")
+
+web_library(
+    name = "library",
+    deps = [],
+    srcs = [
+        "missing-file-label.js",
+    ],
+)

--- a/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only-dep/package.json
+++ b/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-missing-file-label-only-dep",
+  "version": "0.0.0"
+}

--- a/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only/package.json
+++ b/tests/fixtures/find-changed-targets/bazel/test-missing-file-label-only/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-missing-file-label-only",
+  "version": "0.0.0",
+  "dependencies": {
+    "test-missing-file-label-only-dep": "0.0.0"
+  }
+}

--- a/tests/fixtures/find-changed-targets/bazel/test-missing-file/package.json
+++ b/tests/fixtures/find-changed-targets/bazel/test-missing-file/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-missing-file",
+  "version": "0.0.0",
+  "dependencies": {
+    "test-missing-file-dep": "0.0.0"
+  }
+}

--- a/tests/fixtures/find-changed-targets/bazel/yarn.lock
+++ b/tests/fixtures/find-changed-targets/bazel/yarn.lock
@@ -37,3 +37,31 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   languageName: unknown
   linkType: soft
+
+"test-missing-file-dep@0.0.0, test-missing-file-dep@workspace:test-missing-file-dep":
+  version: 0.0.0-use.local
+  resolution: "test-missing-file-dep@workspace:test-missing-file-dep"
+  languageName: unknown
+  linkType: soft
+
+"test-missing-file-label-only-dep@0.0.0, test-missing-file-label-only-dep@workspace:test-missing-file-label-only-dep":
+  version: 0.0.0-use.local
+  resolution: "test-missing-file-label-only-dep@workspace:test-missing-file-label-only-dep"
+  languageName: unknown
+  linkType: soft
+
+"test-missing-file-label-only@workspace:test-missing-file-label-only":
+  version: 0.0.0-use.local
+  resolution: "test-missing-file-label-only@workspace:test-missing-file-label-only"
+  dependencies:
+    test-missing-file-label-only-dep: 0.0.0
+  languageName: unknown
+  linkType: soft
+
+"test-missing-file@workspace:test-missing-file":
+  version: 0.0.0-use.local
+  resolution: "test-missing-file@workspace:test-missing-file"
+  dependencies:
+    test-missing-file-dep: 0.0.0
+  languageName: unknown
+  linkType: soft

--- a/tests/index.js
+++ b/tests/index.js
@@ -923,6 +923,8 @@ async function testFindChangedTargets() {
 
     const root = `${tmp}/tmp/find-changed-targets/bazel`;
     const files = `${tmp}/tmp/find-changed-targets/bazel/changes.txt`;
+    const missingFiles = `${tmp}/tmp/find-changed-targets/bazel/changes-missing-files.txt`;
+    const missingFilesLabelOnly = `${tmp}/tmp/find-changed-targets/bazel/changes-missing-files-label-only.txt`;
     await install({
       root: `${tmp}/tmp/find-changed-targets/bazel`,
       cwd: `${tmp}/tmp/find-changed-targets/bazel`,
@@ -944,6 +946,35 @@ async function testFindChangedTargets() {
         '//b:lint',
         '//b:test',
         '//d:library', // this should appear here because it depends on non-js/x.txt
+      ].sort()
+    );
+
+    const recoveredTargetsDirs = await findChangedTargets({
+      root,
+      files: missingFiles,
+      format: 'dirs',
+    });
+    assert.deepEqual(
+      recoveredTargetsDirs.sort(),
+      [
+        'test-missing-file',
+        'test-missing-file-dep',
+        'test-missing-file-label-only',
+        'test-missing-file-label-only-dep',
+      ].sort()
+    );
+
+    // Happy path: underlying bazel query returns known labels for missing files
+    const recoveredTargetsDirsLabelOnly = await findChangedTargets({
+      root,
+      files: missingFilesLabelOnly,
+      format: 'dirs',
+    });
+    assert.deepEqual(
+      recoveredTargetsDirsLabelOnly.sort(),
+      [
+        'test-missing-file-label-only',
+        'test-missing-file-label-only-dep',
       ].sort()
     );
   }

--- a/utils/bazel-commands.js
+++ b/utils/bazel-commands.js
@@ -10,6 +10,7 @@ const startupFlags = ['--host_jvm_args=-Xmx15g'];
 
 /*::
 import type {Stdio} from './node-helpers.js';
+export type {ExecException as BazelQueryException} from './node-helpers.js';
 
 export type BuildArgs = {
   root: string,


### PR DESCRIPTION
This change addresses a scenario where removed files may still be referenced in build files. Previously, `jazelle changes` would return an empty set in such cases. The update involves reading the bazel query's stdout to utilize known labels in subsequent queries.

