### PR TITLE
Remove bazel startup options in favor of .bazelrc

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -50,7 +50,7 @@ run() {
     ACTUAL_VERSION=$(cat "$ROOT/bazel-bin/jazelle.runfiles/jazelle/package.json" | grep version | awk '{print substr($2, 2, length($2) - 3)}')
     if ! grep "$ACTUAL_VERSION" "$ROOT/WORKSPACE" || [[ $ACTUAL_VERSION = "" ]] || [ ! -f "$ROOT/bazel-bin/jazelle.runfiles/jazelle/bin/cli.sh" ]
     then
-      "$BAZELISK_PATH" --host_jvm_args=-Xmx15g run //:jazelle -- setup 2>/tmp/jazelle.log || true
+      "$BAZELISK_PATH" run //:jazelle -- setup 2>/tmp/jazelle.log || true
     fi
   fi
 }

--- a/commands/bazel.js
+++ b/commands/bazel.js
@@ -2,7 +2,6 @@
 const {bazel} = require('../utils/binary-paths.js');
 const {spawnOrExit} = require('../utils/node-helpers.js');
 const {getPassThroughArgs} = require('../utils/parse-argv.js');
-const {startupFlags} = require('../utils/bazel-commands.js');
 
 /*::
 import type {Stdio} from '../utils/node-helpers.js';
@@ -16,7 +15,7 @@ export type Bazel = (BazelArgs) => Promise<void>
 */
 const runBazel /*: Bazel */ = async ({root, args, stdio = 'inherit'}) => {
   const params = getPassThroughArgs(args);
-  await spawnOrExit(bazel, [...startupFlags, ...params], {
+  await spawnOrExit(bazel, [...params], {
     stdio,
     env: {...process.env},
     cwd: root,

--- a/utils/bazel-commands.js
+++ b/utils/bazel-commands.js
@@ -6,8 +6,6 @@ const {randomBytes} = require('crypto');
 const {bazel, node} = require('./binary-paths.js');
 const {spawnOrExit, exec: nodeExec} = require('./node-helpers.js');
 
-const startupFlags = ['--host_jvm_args=-Xmx15g'];
-
 /*::
 import type {Stdio} from './node-helpers.js';
 export type {ExecException as BazelQueryException} from './node-helpers.js';
@@ -27,7 +25,7 @@ const build /*: Build */ = async ({
   stdio = 'inherit',
 }) => {
   cwd = relative(root, cwd);
-  await spawnOrExit(bazel, [...startupFlags, 'build', `//${cwd}:${name}`], {
+  await spawnOrExit(bazel, ['build', `//${cwd}:${name}`], {
     stdio,
     env: {...process.env},
     cwd: root,
@@ -53,15 +51,11 @@ const test /*: Test */ = async ({
 }) => {
   cwd = relative(root, cwd);
   const testParams = args.map(arg => `--test_arg=${arg}`);
-  await spawnOrExit(
-    bazel,
-    [...startupFlags, 'run', `//${cwd}:${name}`, ...testParams],
-    {
-      stdio,
-      env: {...process.env},
-      cwd: root,
-    }
-  );
+  await spawnOrExit(bazel, ['run', `//${cwd}:${name}`, ...testParams], {
+    stdio,
+    env: {...process.env},
+    cwd: root,
+  });
 };
 
 /*::
@@ -83,15 +77,11 @@ const run /*: Run */ = async ({
 }) => {
   cwd = relative(root, cwd);
   const runParams = args.length > 0 ? ['--', ...args] : [];
-  await spawnOrExit(
-    bazel,
-    [...startupFlags, 'run', `//${cwd}:${name}`, ...runParams],
-    {
-      stdio,
-      env: {...process.env},
-      cwd: root,
-    }
-  );
+  await spawnOrExit(bazel, ['run', `//${cwd}:${name}`, ...runParams], {
+    stdio,
+    env: {...process.env},
+    cwd: root,
+  });
 };
 
 /*::
@@ -232,7 +222,6 @@ const bazelQuery /*: BazelQuery */ = async ({cwd, query, args = []}) => {
 };
 
 module.exports = {
-  startupFlags,
   bazelQuery,
   build,
   test,


### PR DESCRIPTION
Remove default startup options from bazel invocations in favor of the user/project configuration specified in the `.bazelrc`. This avoids introducing changes that would cause the server to restart between bazel invocations, reducing the likelihood of cache invalidation. E.g.,
```
# `jz changes` command invokes bazel w/ different startup options (main invocation vs. subsequent `bazel query`)
% echo "WORKSPACE" | jz changes
...
# Running build after `jz changes` will require restarting the server, as startup options are different from the `bazel query`, which invalidates all analysis cache
% jz noop
WARNING: Running Bazel server needs to be killed, because the startup options are different.
Starting local Bazel server and connecting to it...
```

Example .bazelrc:
```
startup --host_jvm_args="-Xmx15g"
```
