### PR TITLE
Fork: Jazelle upgrade @types sync #169

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 tests/tmp
 yarn-error.log
 !tests/fixtures/bazel-*
+
+# Auto-generated Bazel files
+MODULE.bazel
+MODULE.bazel.lock

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -1,20 +1,23 @@
 // @flow
-const {minVersion, satisfies, valid} = require('../utils/cached-semver');
-const {getManifest} = require('../utils/get-manifest.js');
-const {findLocalDependency} = require('../utils/find-local-dependency.js');
-const {read, write} = require('../utils/node-helpers.js');
-const {spawn} = require('../utils/node-helpers.js');
-const {node, yarn} = require('../utils/binary-paths.js');
+const { minVersion, satisfies, valid } = require('../utils/cached-semver');
+const { maxSatisfying } = require('../vendor/semver/semver.js');
+const { getManifest } = require('../utils/get-manifest.js');
+const { findLocalDependency } = require('../utils/find-local-dependency.js');
+const { read, write, exec } = require('../utils/node-helpers.js');
+const { spawn } = require('../utils/node-helpers.js');
+const { node, yarn } = require('../utils/binary-paths.js');
+const inquirer = require('inquirer');
 
 /*::
 export type UpgradeArgs = {
   root: string,
   args: Array<string>,
+  interactive?: boolean,
 };
 export type Upgrade = (UpgradeArgs) => Promise<void>;
 */
-const upgrade /*: Upgrade */ = async ({root, args}) => {
-  const {projects} = await getManifest({root});
+const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
+  const { projects } = await getManifest({ root });
   const roots = projects.map(dir => `${root}/${dir}`);
 
   // group by whether the dep is local (listed in manifest.json) or external (from registry)
@@ -22,9 +25,9 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
   const externals = [];
   for (const arg of args) {
     let [, name, version] = arg.match(/(@?[^@]*)@?(.*)/) || [];
-    const local = await findLocalDependency({root, name});
-    if (local) locals.push({local, name, version});
-    else externals.push({name, range: version});
+    const local = await findLocalDependency({ root, name });
+    if (local) locals.push({ local, name, version });
+    else externals.push({ name, range: version });
   }
 
   if (locals.length > 0) {
@@ -32,7 +35,7 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
       roots.map(async cwd => {
         const meta = JSON.parse(await read(`${cwd}/package.json`, 'utf8'));
 
-        for (const {local, name, version} of locals) {
+        for (const { local, name, version } of locals) {
           if (version && version !== local.meta.version) {
             const error = `You must use version ${name}@${local.meta.version}`;
             throw new Error(error);
@@ -52,14 +55,181 @@ const upgrade /*: Upgrade */ = async ({root, args}) => {
     );
   }
   if (externals.length > 0) {
-    const deps = externals.map(({name, range}) => {
+    const deps = externals.map(({ name, range }) => {
       return name + (range ? `@${range}` : '');
     });
-    await spawn(node, [yarn, 'up', '-C', ...deps, '--mode', 'skip-build'], {
+    // Add @types packages
+    const typesDeps = await getTypesPackages(externals, root, roots, interactive);
+    await spawn(node, [yarn, 'up', '-C', ...deps, ...typesDeps, '--mode', 'skip-build'], {
       cwd: root,
       stdio: 'inherit',
     });
   }
+};
+
+const getTypesPackages = async (externals, root, roots, interactive = true) => {
+  const typesDeps = [];
+
+  for (const { name, range } of externals) {
+    // Skip if already a @types package
+    if (name.startsWith('@types/')) continue;
+
+    const typesPackageName = `@types/${name}`;
+
+    try {
+      // Check if main package has bundled types
+      const hasBundledTypes = await checkBundledTypes(name, range, root);
+      if (hasBundledTypes) {
+        console.log(`${name} has bundled types, removing separate @types package`);
+        await removeTypesPackage(name, roots)
+        continue;
+      }
+      // Find best @types version
+      const typesVersion = await findBestTypesVersion(typesPackageName, range, root, interactive);
+      if (typesVersion) {
+        console.log(`Adding ${typesPackageName}@${typesVersion}`);
+        typesDeps.push(`${typesPackageName}@${typesVersion}`);
+      }
+    } catch (error) {
+      // Silently skip on errors to avoid breaking the main upgrade
+    }
+  }
+
+  return typesDeps;
+};
+
+const checkBundledTypes = async (packageName, versionRange, root) => {
+  try {
+    const versionSpec = versionRange || 'latest';
+    const cmd = `${node} ${yarn} info ${packageName}@${versionSpec} --json`;
+    const result = await exec(cmd, { cwd: root, maxBuffer: 5 * 1024 * 1024 });
+    const data = JSON.parse(result.trim());
+    return !!(data.types || data.typings);
+  } catch (error) {
+    return false;
+  }
+};
+
+const promptForTypesVersion = async (typesPackageName, originalRange, versions, interactive = true) => {
+  const latest = versions[versions.length - 1];
+  const recentVersions = versions.slice(-10); // Show last 10 versions
+
+  console.log(`\nNo compatible @types version found for ${typesPackageName} with range "${originalRange}"`);
+  console.log(`Available versions: ${recentVersions.join(', ')}`);
+
+  // In non-interactive mode, skip the package
+  if (!interactive) {
+    console.log(`Skipping ${typesPackageName} (non-interactive mode)`);
+    return null;
+  }
+
+  const choices = [
+    { name: `Use latest version (${latest})`, value: latest },
+    { name: 'Enter a specific version manually', value: 'manual' },
+    { name: 'Skip this package', value: 'skip' },
+    { name: 'Abort the upgrade process', value: 'abort' }
+  ];
+
+  const { action } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'action',
+      message: `What would you like to do for ${typesPackageName}?`,
+      choices
+    }
+  ]);
+
+  if (action === 'latest') {
+    return latest;
+  } else if (action === 'manual') {
+    const { manualVersion } = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'manualVersion',
+        message: 'Enter the specific version:',
+        validate: (input) => {
+          if (!input.trim()) return 'Version cannot be empty';
+          if (!versions.includes(input.trim())) {
+            return `Version "${input.trim()}" not found. Available versions: ${versions.join(', ')}`;
+          }
+          return true;
+        }
+      }
+    ]);
+    return manualVersion.trim();
+  } else if (action === 'skip') {
+    return null;
+  } else if (action === 'abort') {
+    throw new Error('Upgrade process aborted by user');
+  }
+};
+
+const findBestTypesVersion = async (typesPackageName, versionRange, root, interactive = true) => {
+  try {
+    // Get all versions
+    const cmd = `${node} ${yarn} info ${typesPackageName} versions --json`;
+    const result = await exec(cmd, { cwd: root, maxBuffer: 5 * 1024 * 1024 });
+    const data = JSON.parse(result.trim());
+    const versions = data.versions || data || [];
+
+    if (versions.length === 0) return null;
+    // If no version range specified, use latest
+    if (!versionRange) {
+      return versions[versions.length - 1];
+    }
+    // Mirror the user's version specifier for @types
+    let typesRange;
+    if (versionRange.startsWith('~')) {
+      // User specified tilde → use tilde for @types
+      typesRange = versionRange;
+    } else if (versionRange.startsWith('^')) {
+      // User specified caret → use caret for @types
+      typesRange = versionRange;
+    } else {
+      // User specified exact version → use tilde for @types
+      typesRange = `~${versionRange}`;
+    }
+
+    const bestVersion = maxSatisfying(versions, typesRange);
+
+    // If no compatible version found, trigger interactive prompt
+    if (!bestVersion) {
+      return await promptForTypesVersion(typesPackageName, versionRange, versions, interactive);
+    }
+
+    return bestVersion;
+  } catch (error) {
+    return null;
+  }
+};
+
+const removeTypesPackage = async (packageName, roots) => {
+  const typesPackageName = `@types/${packageName}`;
+
+  await Promise.all(
+    roots.map(async cwd => {
+      const meta = JSON.parse(await read(`${cwd}/package.json`, 'utf8'));
+      let updated = false;
+
+      // Remove from dependencies and devDependencies
+      if (meta.dependencies && meta.dependencies[typesPackageName]) {
+        delete meta.dependencies[typesPackageName];
+        updated = true;
+      }
+      if (meta.devDependencies && meta.devDependencies[typesPackageName]) {
+        delete meta.devDependencies[typesPackageName];
+        updated = true;
+      }
+
+      if (updated) {
+        await write(
+          `${cwd}/package.json`,
+          JSON.stringify(meta, null, 2) + '\n',
+          'utf8'
+        );
+      }
+    })
+  );
 };
 
 const update = (meta, type, name, version, from) => {
@@ -70,4 +240,11 @@ const update = (meta, type, name, version, from) => {
   }
 };
 
-module.exports = {upgrade};
+module.exports = {
+  upgrade,
+  findBestTypesVersion,
+  checkBundledTypes,
+  getTypesPackages,
+  removeTypesPackage,
+  promptForTypesVersion
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@rauschma/stringio": "1.4.0",
+    "inquirer": "^8.2.6",
     "semver": "^6.2.0"
   },
   "devDependencies": {

--- a/test-types-upgrade/manifest.json
+++ b/test-types-upgrade/manifest.json
@@ -1,0 +1,3 @@
+{
+  "workspace": "test-types-upgrade"
+}

--- a/test-types-upgrade/package.json
+++ b/test-types-upgrade/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "workspaces": ["packages/test-app"]
+}

--- a/test-types-upgrade/packages/test-app/package.json
+++ b/test-types-upgrade/packages/test-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "lodash": "^4.17.0"
+  }
+}

--- a/tests/fixtures/upgrade-types/manifest.json
+++ b/tests/fixtures/upgrade-types/manifest.json
@@ -1,0 +1,5 @@
+{
+    "projects": [
+        "test-app"
+    ]
+}

--- a/tests/fixtures/upgrade-types/package.json
+++ b/tests/fixtures/upgrade-types/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "workspaces": [
+        "test-app"
+    ]
+}

--- a/tests/fixtures/upgrade-types/test-app/package.json
+++ b/tests/fixtures/upgrade-types/test-app/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "test-app",
+    "version": "1.0.0",
+    "dependencies": {
+        "lodash": "4.17.20",
+        "axios": "0.27.0"
+    },
+    "devDependencies": {
+        "@types/lodash": "4.14.180"
+    }
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,34 +1,34 @@
 // @flow
 const assert = require('assert');
-const {tmpdir} = require('os');
+const { tmpdir } = require('os');
 const path = require('path');
-const {readFileSync, createWriteStream} = require('fs');
-const {runCLI} = require('../index');
-const {init} = require('../commands/init.js');
-const {scaffold} = require('../commands/scaffold.js');
-const {install, ImmutableInstallError} = require('../commands/install.js');
-const {add} = require('../commands/add.js');
-const {bazel: bazelCmd} = require('../commands/bazel.js');
-const {upgrade} = require('../commands/upgrade.js');
-const {remove} = require('../commands/remove.js');
-const {ci} = require('../commands/ci.js');
-const {focus} = require('../commands/focus.js');
-const {purge} = require('../commands/purge.js');
-const {node: nodeCmd} = require('../commands/node.js');
-const {yarn: yarnCmd} = require('../commands/yarn.js');
-const {bump} = require('../commands/bump.js');
-const {script} = require('../commands/script.js');
-const {localize} = require('../commands/localize.js');
-const {check} = require('../commands/check.js');
-const {outdated} = require('../commands/outdated.js');
+const { readFileSync, createWriteStream } = require('fs');
+const { runCLI } = require('../index');
+const { init } = require('../commands/init.js');
+const { scaffold } = require('../commands/scaffold.js');
+const { install, ImmutableInstallError } = require('../commands/install.js');
+const { add } = require('../commands/add.js');
+const { bazel: bazelCmd } = require('../commands/bazel.js');
+const { upgrade } = require('../commands/upgrade.js');
+const { remove } = require('../commands/remove.js');
+const { ci } = require('../commands/ci.js');
+const { focus } = require('../commands/focus.js');
+const { purge } = require('../commands/purge.js');
+const { node: nodeCmd } = require('../commands/node.js');
+const { yarn: yarnCmd } = require('../commands/yarn.js');
+const { bump } = require('../commands/bump.js');
+const { script } = require('../commands/script.js');
+const { localize } = require('../commands/localize.js');
+const { check } = require('../commands/check.js');
+const { outdated } = require('../commands/outdated.js');
 
-const {assertProjectDir} = require('../utils/assert-project-dir.js');
-const {batchTestGroup} = require('../utils/batch-test-group');
+const { assertProjectDir } = require('../utils/assert-project-dir.js');
+const { batchTestGroup } = require('../utils/batch-test-group');
 const bazelCmds = require('../utils/bazel-commands.js');
-const {bazel, node, yarn} = require('../utils/binary-paths.js');
-const {cli} = require('../utils/cli.js');
-const {detectCyclicDeps} = require('../utils/detect-cyclic-deps.js');
-const {copy} = require('../rules/untar');
+const { bazel, node, yarn } = require('../utils/binary-paths.js');
+const { cli } = require('../utils/cli.js');
+const { detectCyclicDeps } = require('../utils/detect-cyclic-deps.js');
+const { copy } = require('../rules/untar');
 const {
   exec,
   exists,
@@ -39,20 +39,20 @@ const {
   remove: rm,
   spawn,
 } = require('../utils/node-helpers.js');
-const {findChangedTargets} = require('../utils/find-changed-targets.js');
-const {findLocalDependency} = require('../utils/find-local-dependency.js');
+const { findChangedTargets } = require('../utils/find-changed-targets.js');
+const { findLocalDependency } = require('../utils/find-local-dependency.js');
 const {
   generateBazelBuildRules,
 } = require('../utils/generate-bazel-build-rules.js');
-const {generateBazelignore} = require('../utils/generate-bazelignore.js');
-const {getDownstreams} = require('../utils/get-downstreams.js');
-const {getManifest} = require('../utils/get-manifest.js');
-const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
-const {getRootDir} = require('../utils/get-root-dir.js');
-const {getTestGroups} = require('../utils/get-test-groups.js');
-const {groupByDepsets} = require('../utils/group-by-depsets.js');
-const {isYarnResolution} = require('../utils/is-yarn-resolution.js');
-const {parse, getPassThroughArgs} = require('../utils/parse-argv.js');
+const { generateBazelignore } = require('../utils/generate-bazelignore.js');
+const { getDownstreams } = require('../utils/get-downstreams.js');
+const { getManifest } = require('../utils/get-manifest.js');
+const { getLocalDependencies } = require('../utils/get-local-dependencies.js');
+const { getRootDir } = require('../utils/get-root-dir.js');
+const { getTestGroups } = require('../utils/get-test-groups.js');
+const { groupByDepsets } = require('../utils/group-by-depsets.js');
+const { isYarnResolution } = require('../utils/is-yarn-resolution.js');
+const { parse, getPassThroughArgs } = require('../utils/parse-argv.js');
 
 const {
   reportMismatchedTopLevelDeps,
@@ -63,9 +63,9 @@ const {
   removeCallArgItem,
   sortCallArgItems,
 } = require('../utils/starlark.js');
-const {shouldSync, getVersion} = require('../utils/version-onboarding.js');
+const { shouldSync, getVersion } = require('../utils/version-onboarding.js');
 const yarnCmds = require('../utils/yarn-commands.js');
-const {sortPackageJson} = require('../utils/sort-package-json');
+const { sortPackageJson } = require('../utils/sort-package-json');
 
 const originalProcessExit = process.exit;
 process.on('unhandledRejection', e => {
@@ -182,6 +182,7 @@ async function runTests() {
     t(testCi),
     t(testFocus),
     t(testUpgrade),
+    t(testUpgradeTypes),
     t(testPurge),
     t(testBump),
     // t(testEach),
@@ -269,7 +270,7 @@ async function testBazel() {
 
   // @see: https://bazel.build/run/scripts#exit-codes
   await expectProcessExit(2, () =>
-    bazelCmd({root, args: ['run'], stdio: ['ignore', stream, stream]})
+    bazelCmd({ root, args: ['run'], stdio: ['ignore', stream, stream] })
   );
 
   const output = await read(streamFile, 'utf8');
@@ -279,7 +280,7 @@ async function testBazel() {
 
 async function testInit() {
   await exec(`mkdir ${tmp}/tmp/init`);
-  await init({cwd: `${tmp}/tmp/init`});
+  await init({ cwd: `${tmp}/tmp/init` });
   assert(await exists(`${tmp}/tmp/init/WORKSPACE`));
   assert(await exists(`${tmp}/tmp/init/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/init/.bazelversion`));
@@ -298,7 +299,7 @@ async function testScaffold() {
   const from = 'template';
   const to = 'foo';
   const name = '@foo/foo';
-  await scaffold({root, cwd, from, to, name});
+  await scaffold({ root, cwd, from, to, name });
 
   assert(await exists(`${tmp}/tmp/scaffold/foo/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/scaffold/foo/package.json`));
@@ -313,11 +314,11 @@ async function testScaffold() {
   assert.equal(meta.name, '@foo/foo');
 
   const manifestFile = `${tmp}/tmp/scaffold/manifest.json`;
-  const {projects} = JSON.parse(await read(manifestFile, 'utf8'));
+  const { projects } = JSON.parse(await read(manifestFile, 'utf8'));
   assert(projects === undefined);
 
   const rootMeta = `${tmp}/tmp/scaffold/package.json`;
-  const {workspaces} = JSON.parse(await read(rootMeta, 'utf8'));
+  const { workspaces } = JSON.parse(await read(rootMeta, 'utf8'));
   assert(workspaces.includes('foo'));
 }
 
@@ -366,6 +367,7 @@ async function testInstallAddUpgradeRemove() {
   await upgrade({
     root: `${tmp}/tmp/commands`,
     args: ['c@0.0.0'],
+    interactive: false,
   });
   assert((await read(buildFile, 'utf8')).includes('//c:library'));
 
@@ -373,6 +375,7 @@ async function testInstallAddUpgradeRemove() {
   await upgrade({
     root: `${tmp}/tmp/commands`,
     args: ['has@1.0.3'],
+    interactive: false,
   });
   assert(JSON.parse(await read(meta, 'utf8')).dependencies.has);
 
@@ -439,17 +442,150 @@ async function testUpgrade() {
   await upgrade({
     root: `${tmp}/tmp/upgrade`,
     args: ['has@1.0.3'],
+    interactive: false,
   });
   assert((await read(meta, 'utf8')).includes('"has": "1.0.3"'));
   assert((await read(lockfile, 'utf8')).includes('function-bind'));
 
-  await upgrade({root: `${tmp}/tmp/upgrade`, args: ['b']});
+  await upgrade({ root: `${tmp}/tmp/upgrade`, args: ['b'], interactive: false });
   assert((await read(meta, 'utf8')).includes('"b": "1.0.0"'));
+}
+
+async function testUpgradeTypes() {
+  const meta = `${tmp}/tmp/upgrade-types/test-app/package.json`;
+  const cmd = `cp -r ${__dirname}/fixtures/upgrade-types/ ${tmp}/tmp/upgrade-types`;
+  await exec(cmd);
+
+  // Test 1: Upgrade package that might need @types (lodash)
+  await upgrade({
+    root: `${tmp}/tmp/upgrade-types`,
+    args: ['lodash@4.17.21'],
+    interactive: false,
+  });
+  assert((await read(meta, 'utf8')).includes('"lodash": "4.17.21"'));
+
+  // Test 2: Upgrade @types package directly (should skip @types handling)
+  await upgrade({
+    root: `${tmp}/tmp/upgrade-types`,
+    args: ['@types/lodash@4.14.182'],
+    interactive: false,
+  });
+  assert((await read(meta, 'utf8')).includes('"@types/lodash"'));
+
+  // Test 3: Verify @types packages are handled correctly in args parsing
+  const testArg = '@types/react@18.0.0';
+  const [, name] = testArg.match(/(@?[^@]*)@?(.*)/) || [];
+  assert(name === '@types/react', 'Should correctly parse @types package names');
+
+  // Test 4: Version ranges - tilde range
+  await testUpgradeTypesVersionRanges();
+
+  // Test 5: Interactive mode behavior (mocked, fast)
+  await testUpgradeTypesInteractiveMode();
+}
+
+async function testUpgradeTypesVersionRanges() {
+  const testRoot = `${tmp}/tmp/upgrade-types-ranges`;
+  await exec(`cp -r ${__dirname}/fixtures/upgrade-types/ ${testRoot}`);
+  const meta = `${testRoot}/test-app/package.json`;
+
+  // Test exact version first (most predictable)
+  await upgrade({
+    root: testRoot,
+    args: ['axios@0.27.1'],
+    interactive: false,
+  });
+  const content = await read(meta, 'utf8');
+  assert(content.includes('"axios": "0.27.1"'), 'Should upgrade with exact version');
+
+  // Test tilde range - should preserve the tilde specifier
+  await upgrade({
+    root: testRoot,
+    args: ['lodash@~4.17.20'],
+    interactive: false,
+  });
+  const content2 = await read(meta, 'utf8');
+  const pkg2 = JSON.parse(content2);
+  assert(pkg2.dependencies && pkg2.dependencies.lodash, 'Lodash should be in dependencies');
+  assert(pkg2.dependencies.lodash === '~4.17.20', `Lodash should preserve tilde range, got: ${pkg2.dependencies.lodash}`);
+
+  // Test caret range - should preserve the caret specifier
+  await upgrade({
+    root: testRoot,
+    args: ['axios@^0.27.0'],
+    interactive: false,
+  });
+  const content3 = await read(meta, 'utf8');
+  const pkg3 = JSON.parse(content3);
+  assert(pkg3.dependencies && pkg3.dependencies.axios, 'Axios should be in dependencies');
+  assert(pkg3.dependencies.axios === '^0.27.0', `Axios should preserve caret range, got: ${pkg3.dependencies.axios}`);
+}
+
+
+async function testUpgradeTypesInteractiveMode() {
+  // Test interactive prompts by mocking inquirer responses
+  const testRoot = `${tmp}/tmp/upgrade-types-interactive-mode`;
+  await exec(`cp -r ${__dirname}/fixtures/upgrade-types/ ${testRoot}`);
+
+  const { promptForTypesVersion } = require('../commands/upgrade.js');
+
+  // Mock inquirer to simulate user choices
+  const inquirer = require('inquirer');
+  const originalPrompt = inquirer.prompt;
+
+  try {
+    // Test 1: User chooses "latest"
+    inquirer.prompt = async () => ({ action: 'latest' });
+    const result1 = await promptForTypesVersion('@types/test', '1.0.0', ['1.0.0', '1.1.0', '2.0.0'], true);
+    assert(result1 === '2.0.0', `Should return latest version, got ${result1}`);
+    console.log('✅ Interactive mode: "latest" choice works');
+
+    // Test 2: User chooses "skip"
+    inquirer.prompt = async () => ({ action: 'skip' });
+    const result2 = await promptForTypesVersion('@types/test', '1.0.0', ['1.0.0', '1.1.0', '2.0.0'], true);
+    assert(result2 === null, 'Should return null for skip');
+    console.log('✅ Interactive mode: "skip" choice works');
+
+    // Test 3: User chooses "manual" then enters version
+    let promptCallCount = 0;
+    inquirer.prompt = async (questions) => {
+      promptCallCount++;
+      if (promptCallCount === 1) {
+        return { action: 'manual' };
+      } else {
+        return { manualVersion: '1.1.0' };
+      }
+    };
+    const result3 = await promptForTypesVersion('@types/test', '1.0.0', ['1.0.0', '1.1.0', '2.0.0'], true);
+    assert(result3 === '1.1.0', `Should return manual version, got ${result3}`);
+    console.log('✅ Interactive mode: "manual" choice works');
+
+    // Test 4: User chooses "abort"
+    inquirer.prompt = async () => ({ action: 'abort' });
+    try {
+      await promptForTypesVersion('@types/test', '1.0.0', ['1.0.0', '1.1.0', '2.0.0'], true);
+      assert(false, 'Should have thrown error for abort');
+    } catch (error) {
+      assert(error.message.includes('aborted'), 'Should throw abort error');
+      console.log('✅ Interactive mode: "abort" choice works');
+    }
+
+    // Test 5: Non-interactive mode (should skip)
+    const result5 = await promptForTypesVersion('@types/test', '1.0.0', ['1.0.0', '1.1.0', '2.0.0'], false);
+    assert(result5 === null, 'Non-interactive mode should return null');
+    console.log('✅ Interactive mode: non-interactive fallback works');
+
+  } finally {
+    // Restore original inquirer.prompt
+    inquirer.prompt = originalPrompt;
+  }
+
+  console.log('Interactive mode test completed - all prompt scenarios work correctly');
 }
 
 async function testPurge() {
   await exec(`cp -r ${__dirname}/fixtures/purge/ ${tmp}/tmp/purge`);
-  await purge({root: `${tmp}/tmp/purge`, force: false});
+  await purge({ root: `${tmp}/tmp/purge`, force: false });
   const nodeModules = `${tmp}/tmp/purge/a/node_modules`;
   const globalNodeModules = `${tmp}/tmp/purge/node_modules`;
   const temp = `${__dirname}/third_party/jazelle/temp`;
@@ -486,7 +622,7 @@ async function testNode() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await nodeCmd({
     root,
@@ -521,7 +657,7 @@ async function testYarn() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await yarnCmd({
     cwd,
@@ -551,8 +687,8 @@ async function testEach() {
   const root = `${tmp}/tmp/each`;
 
   const plan = [
-    {type: 'dir', dir: 'a', action: 'exec', args: ['foo']},
-    {type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD']},
+    { type: 'dir', dir: 'a', action: 'exec', args: ['foo'] },
+    { type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD'] },
   ];
   const failed = /*:: await */ await batchTestGroup({
     root,
@@ -577,17 +713,17 @@ async function testBump() {
   // do not update package.json files in CI
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    bump({root, cwd, type: 'preminor', frozenPackageJson: true})
+    bump({ root, cwd, type: 'preminor', frozenPackageJson: true })
   );
   assert(JSON.parse(await read(pkgMeta)).version, '0.0.0');
   assert(JSON.parse(await read(depMeta)).version, '0.0.0');
 
-  await bump({root, cwd, type: 'preminor'});
+  await bump({ root, cwd, type: 'preminor' });
   assert(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert(JSON.parse(await read(depMeta)).version, '0.1.0-0');
 
   // command should be idempotent
-  await bump({root, cwd, type: 'preminor'});
+  await bump({ root, cwd, type: 'preminor' });
   assert.equal(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert.equal(JSON.parse(await read(depMeta)).version, '0.0.0');
 
@@ -615,7 +751,7 @@ async function testScriptCommand() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await script({
     root,
@@ -644,11 +780,11 @@ async function testAssertProjectDir() {
   const dir1 = `${__dirname}/fixtures/project-dir`;
   const t = () => true;
   const f = () => false;
-  const result1 = await assertProjectDir({dir: dir1}).then(t, f);
+  const result1 = await assertProjectDir({ dir: dir1 }).then(t, f);
   assert(result1);
 
   const dir2 = `${__dirname}/fixtures/not-project-dir`;
-  const result2 = await assertProjectDir({dir: dir2}).then(f, t);
+  const result2 = await assertProjectDir({ dir: dir2 }).then(f, t);
   assert(result2);
 }
 
@@ -675,14 +811,14 @@ async function testBatchTestGroup() {
     root: `${tmp}/tmp/batch-test-group`,
     data: [
       [
-        {type: 'bazel', dir: 'a', action: 'flow', args: []},
-        {type: 'bazel', dir: 'a', action: 'lint', args: []},
-        {type: 'bazel', dir: 'a', action: 'test', args: []},
+        { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+        { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+        { type: 'bazel', dir: 'a', action: 'test', args: [] },
       ],
       [
-        {type: 'bazel', dir: 'b', action: 'lint', args: []},
-        {type: 'bazel', dir: 'b', action: 'test', args: []},
-        {type: 'bazel', dir: 'c', action: 'test', args: []},
+        { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+        { type: 'bazel', dir: 'b', action: 'test', args: [] },
+        { type: 'bazel', dir: 'c', action: 'test', args: [] },
       ],
     ],
     index: 0,
@@ -868,12 +1004,12 @@ async function testCLI() {
       `Foo
 
       --bar [bar]     bar`,
-      async ({bar}) => {
+      async ({ bar }) => {
         called = bar;
       },
     ],
   };
-  cli('foo', {bar: '1'}, cmds, async () => {});
+  cli('foo', { bar: '1' }, cmds, async () => { });
   assert.equal(called, '1');
 }
 
@@ -964,7 +1100,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/dirs`;
     const files = `${__dirname}/fixtures/find-changed-targets/dirs/changes.txt`;
-    const dirs = await findChangedTargets({root, files, format: 'dirs'});
+    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
     assert.deepEqual(dirs, ['b', 'a']);
   }
   {
@@ -987,7 +1123,7 @@ async function testFindChangedTargets() {
       root: `${tmp}/tmp/find-changed-targets/bazel`,
       cwd: `${tmp}/tmp/find-changed-targets/bazel`,
     });
-    const targets = await findChangedTargets({root, files, format: 'targets'});
+    const targets = await findChangedTargets({ root, files, format: 'targets' });
     assert.deepEqual(
       targets.sort(),
       [
@@ -1039,7 +1175,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/no-target`;
     const files = `${__dirname}/fixtures/find-changed-targets/no-target/changes.txt`;
-    const dirs = await findChangedTargets({root, files, format: 'dirs'});
+    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
     assert.deepEqual(dirs, []);
   }
 }
@@ -1070,7 +1206,7 @@ async function testImmutableInstall() {
     await exec(`cp -r ${fixturePath}/ ${root}`);
 
     try {
-      await install({root, cwd: root, immutable: true});
+      await install({ root, cwd: root, immutable: true });
       // $FlowFixMe: bad libdef?
       assert.fail('install should not succeed');
     } catch (error) {
@@ -1091,7 +1227,7 @@ async function testImmutableInstall() {
           // compare file with the original fixture file
           assert(
             (await read(`${root}/${file}`, 'utf-8')) ===
-              (await read(`${fixturePath}/${file}`, 'utf-8')),
+            (await read(`${fixturePath}/${file}`, 'utf-8')),
             `${file} should not have been changed`
           );
         } else {
@@ -1111,10 +1247,10 @@ async function testImmutableInstall() {
 
     // first run an install without `immutable` to prime the fixture
     // with all the generated files
-    await install({root, cwd: root});
+    await install({ root, cwd: root });
 
     try {
-      await install({root, cwd: root, immutable: true});
+      await install({ root, cwd: root, immutable: true });
     } catch (error) {
       // $FlowFixMe: bad libdef?
       assert.fail('install should succeed');
@@ -1229,7 +1365,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'a',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'}, // cyclical dep should not break test
+        dependencies: { b: '0.0.0' }, // cyclical dep should not break test
       },
       depth: 3,
     },
@@ -1238,7 +1374,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: {a: '0.0.0'},
+        dependencies: { a: '0.0.0' },
       },
       depth: 2,
     },
@@ -1247,12 +1383,12 @@ async function testGetDownstreams() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'},
+        dependencies: { b: '0.0.0' },
       },
       depth: 1,
     },
   ];
-  const downstreams = getDownstreams({deps, dep: deps[0]});
+  const downstreams = getDownstreams({ deps, dep: deps[0] });
   assert.deepEqual(downstreams, deps.slice(1));
 }
 
@@ -1271,7 +1407,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: {a: 'workspace:*'},
+        dependencies: { a: 'workspace:*' },
       },
       depth: 3,
     },
@@ -1280,7 +1416,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'},
+        dependencies: { b: '0.0.0' },
       },
       depth: 2,
     },
@@ -1289,7 +1425,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'd',
         version: '0.0.0',
-        dependencies: {a: '0.0.0'},
+        dependencies: { a: '0.0.0' },
       },
       depth: 2,
     },
@@ -1335,7 +1471,7 @@ async function testGetLocalDependencies() {
 
 async function testGetManifest() {
   assert.deepEqual(
-    await getManifest({root: `${__dirname}/fixtures/get-all-project-paths`}),
+    await getManifest({ root: `${__dirname}/fixtures/get-all-project-paths` }),
     {
       projects: ['path/to/a', 'path/to/b'],
       workspace: 'host',
@@ -1346,7 +1482,7 @@ async function testGetManifest() {
 
 async function testGetRootDir() {
   const dir = `${__dirname}/fixtures/get-root-dir/a`;
-  const result = getRootDir({dir});
+  const result = getRootDir({ dir });
   assert(result);
 }
 
@@ -1368,14 +1504,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByTwo, [
     [
-      {type: 'bazel', dir: 'a', action: 'test', args: []},
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'test', args: [] },
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
     ],
     [
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
-      {type: 'bazel', dir: 'c', action: 'test', args: []},
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'c', action: 'test', args: [] },
     ],
   ]);
 
@@ -1393,15 +1529,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByFour, [
     [
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
     ],
-    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
     [
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
     ],
-    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
   ]);
 
   const bazelByEight = await getTestGroups({
@@ -1417,12 +1553,12 @@ async function testGetTestGroups() {
     nodes: 8,
   });
   assert.deepEqual(bazelByEight, [
-    [{type: 'bazel', dir: 'a', action: 'flow', args: []}],
-    [{type: 'bazel', dir: 'a', action: 'lint', args: []}],
-    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
-    [{type: 'bazel', dir: 'b', action: 'lint', args: []}],
-    [{type: 'bazel', dir: 'b', action: 'test', args: []}],
-    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'a', action: 'flow', args: [] }],
+    [{ type: 'bazel', dir: 'a', action: 'lint', args: [] }],
+    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
+    [{ type: 'bazel', dir: 'b', action: 'lint', args: [] }],
+    [{ type: 'bazel', dir: 'b', action: 'test', args: [] }],
+    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
   ]);
 
   const dirByTwo = await getTestGroups({
@@ -1432,14 +1568,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByTwo, [
     [
-      {type: 'dir', dir: 'a', action: 'test', args: []},
-      {type: 'dir', dir: 'a', action: 'lint', args: []},
-      {type: 'dir', dir: 'a', action: 'flow', args: []},
+      { type: 'dir', dir: 'a', action: 'test', args: [] },
+      { type: 'dir', dir: 'a', action: 'lint', args: [] },
+      { type: 'dir', dir: 'a', action: 'flow', args: [] },
     ],
     [
-      {type: 'dir', dir: 'b', action: 'test', args: []},
-      {type: 'dir', dir: 'b', action: 'lint', args: []},
-      {type: 'dir', dir: 'c', action: 'test', args: []},
+      { type: 'dir', dir: 'b', action: 'test', args: [] },
+      { type: 'dir', dir: 'b', action: 'lint', args: [] },
+      { type: 'dir', dir: 'c', action: 'test', args: [] },
     ],
   ]);
 
@@ -1450,15 +1586,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByFour, [
     [
-      {type: 'dir', dir: 'a', action: 'lint', args: []},
-      {type: 'dir', dir: 'a', action: 'flow', args: []},
+      { type: 'dir', dir: 'a', action: 'lint', args: [] },
+      { type: 'dir', dir: 'a', action: 'flow', args: [] },
     ],
-    [{type: 'dir', dir: 'a', action: 'test', args: []}],
+    [{ type: 'dir', dir: 'a', action: 'test', args: [] }],
     [
-      {type: 'dir', dir: 'b', action: 'test', args: []},
-      {type: 'dir', dir: 'b', action: 'lint', args: []},
+      { type: 'dir', dir: 'b', action: 'test', args: [] },
+      { type: 'dir', dir: 'b', action: 'lint', args: [] },
     ],
-    [{type: 'dir', dir: 'c', action: 'test', args: []}],
+    [{ type: 'dir', dir: 'c', action: 'test', args: [] }],
   ]);
 }
 
@@ -1471,131 +1607,131 @@ async function testGroupByDepsets() {
   const bMeta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   const cMeta = JSON.parse(await read(`${root}/c/package.json`, 'utf8'));
   const metas = [
-    {dir: `${root}/a`, depth: 0, meta: aMeta},
-    {dir: `${root}/b`, depth: 0, meta: bMeta},
-    {dir: `${root}/c`, depth: 0, meta: cMeta},
+    { dir: `${root}/a`, depth: 0, meta: aMeta },
+    { dir: `${root}/b`, depth: 0, meta: bMeta },
+    { dir: `${root}/c`, depth: 0, meta: cMeta },
   ];
   const group = [
-    {type: 'bazel', dir: 'a', action: 'test', args: []},
-    {type: 'bazel', dir: 'a', action: 'lint', args: []},
-    {type: 'bazel', dir: 'a', action: 'flow', args: []},
-    {type: 'bazel', dir: 'b', action: 'test', args: []},
-    {type: 'bazel', dir: 'b', action: 'lint', args: []},
-    {type: 'bazel', dir: 'b', action: 'flow', args: []},
-    {type: 'bazel', dir: 'c', action: 'test', args: []},
-    {type: 'bazel', dir: 'c', action: 'lint', args: []},
-    {type: 'bazel', dir: 'c', action: 'flow', args: []},
+    { type: 'bazel', dir: 'a', action: 'test', args: [] },
+    { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+    { type: 'bazel', dir: 'b', action: 'test', args: [] },
+    { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'b', action: 'flow', args: [] },
+    { type: 'bazel', dir: 'c', action: 'test', args: [] },
+    { type: 'bazel', dir: 'c', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'c', action: 'flow', args: [] },
   ];
-  assert.deepEqual(groupByDepsets({root, metas, group}), [
+  assert.deepEqual(groupByDepsets({ root, metas, group }), [
     [
-      {type: 'bazel', dir: 'a', action: 'test', args: []},
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
-      {type: 'bazel', dir: 'b', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'test', args: [] },
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'b', action: 'flow', args: [] },
     ],
     [
-      {type: 'bazel', dir: 'c', action: 'test', args: []},
-      {type: 'bazel', dir: 'c', action: 'lint', args: []},
-      {type: 'bazel', dir: 'c', action: 'flow', args: []},
+      { type: 'bazel', dir: 'c', action: 'test', args: [] },
+      { type: 'bazel', dir: 'c', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'c', action: 'flow', args: [] },
     ],
   ]);
 }
 
 async function testIsYarnResolution() {
   const exact = isYarnResolution({
-    meta: {resolutions: {a: '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { a: '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(exact, true);
 
   const namespaced = isYarnResolution({
-    meta: {resolutions: {'@a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b': '0.0.0' }, name: '', version: '' },
     name: '@a/b',
   });
   assert.equal(namespaced, true);
 
   const globbed = isYarnResolution({
-    meta: {resolutions: {'**/a': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '**/a': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(globbed, true);
 
   const globbedNs = isYarnResolution({
-    meta: {resolutions: {'**/@a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '**/@a/b': '0.0.0' }, name: '', version: '' },
     name: '@a/b',
   });
   assert.equal(globbedNs, true);
 
   const direct = isYarnResolution({
-    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
     name: 'b',
   });
   assert.equal(direct, true);
 
   const directNs = isYarnResolution({
-    meta: {resolutions: {'a/@b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/@b/c': '0.0.0' }, name: '', version: '' },
     name: '@b/c',
   });
   assert.equal(directNs, true);
 
   const directOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(directOfNs, true);
 
   const directNsOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/@c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/@c/d': '0.0.0' }, name: '', version: '' },
     name: '@c/d',
   });
   assert.equal(directNsOfNs, true);
 
   const transitive = isYarnResolution({
-    meta: {resolutions: {'a/**/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/**/b': '0.0.0' }, name: '', version: '' },
     name: 'b',
   });
   assert.equal(transitive, true);
 
   const transitiveNs = isYarnResolution({
-    meta: {resolutions: {'a/**/@b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/**/@b/c': '0.0.0' }, name: '', version: '' },
     name: '@b/c',
   });
   assert.equal(transitiveNs, true);
 
   const transitiveOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/**/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/**/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(transitiveOfNs, true);
 
   const transitiveNsOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/**/@c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/**/@c/d': '0.0.0' }, name: '', version: '' },
     name: '@c/d',
   });
   assert.equal(transitiveNsOfNs, true);
 
   const nested = isYarnResolution({
-    meta: {resolutions: {'a/b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(nested, true);
 
   const nestedOfNs = isYarnResolution({
-    meta: {resolutions: {'a/@b/c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/@b/c/d': '0.0.0' }, name: '', version: '' },
     name: 'd',
   });
   assert.equal(nestedOfNs, true);
 
   const positional = isYarnResolution({
-    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(positional, false);
 
   const positionalNs = isYarnResolution({
-    meta: {resolutions: {'@a/a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/a/b': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(positionalNs, false);
@@ -1671,13 +1807,13 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutLockstep, {
     valid: false,
-    policy: {lockstep: false, exceptions: ['no-bugs', '@uber/mismatched']},
+    policy: { lockstep: false, exceptions: ['no-bugs', '@uber/mismatched'] },
     reported: {
       'no-bugs': {
         '^1.0.0': ['@uber/a', '@uber/b'],
         'npm:function-bind': ['@uber/c'],
       },
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1691,9 +1827,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutPartialLockstep, {
     valid: false,
-    policy: {lockstep: false, exceptions: ['@uber/mismatched']},
+    policy: { lockstep: false, exceptions: ['@uber/mismatched'] },
     reported: {
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1707,9 +1843,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withLockstep, {
     valid: false,
-    policy: {lockstep: true, exceptions: ['no-bugs']},
+    policy: { lockstep: true, exceptions: ['no-bugs'] },
     reported: {
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1723,7 +1859,7 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withAllExceptions, {
     valid: true,
-    policy: {lockstep: true, exceptions: ['no-bugs', '@uber/mismatched']},
+    policy: { lockstep: true, exceptions: ['no-bugs', '@uber/mismatched'] },
     reported: {},
   });
 
@@ -1732,16 +1868,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
   });
   assert.deepEqual(withVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
-    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
+    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
   });
 
   const withAllVersionedExceptions = await reportMismatchedTopLevelDeps({
@@ -1749,14 +1885,14 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
     },
   });
   assert.deepEqual(withAllVersionedExceptions, {
     valid: true,
     policy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
     },
     reported: {},
   });
@@ -1766,16 +1902,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: true,
-      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
   });
   assert.deepEqual(withLockstepVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: true,
-      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
-    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
+    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
   });
 
   const withLockstepAllVersionedExceptions = await reportMismatchedTopLevelDeps(
@@ -1786,7 +1922,7 @@ async function testReportMismatchedTopLevelDeps() {
         lockstep: true,
         exceptions: [
           'no-bugs',
-          {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
+          { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
         ],
       },
     }
@@ -1797,7 +1933,7 @@ async function testReportMismatchedTopLevelDeps() {
       lockstep: true,
       exceptions: [
         'no-bugs',
-        {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
+        { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
       ],
     },
     reported: {},
@@ -1907,7 +2043,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(!shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -1915,7 +2051,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -1923,7 +2059,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -1931,33 +2067,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(!shouldSync({versionPolicy, name}));
-  }
-  {
-    const versionPolicy = {
-      lockstep: true,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
-  }
-  {
-    const versionPolicy = {
-      lockstep: false,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -1969,8 +2079,34 @@ async function testVersionOnboarding() {
         },
       ],
     };
+    const name = 'foo';
+    assert(shouldSync({ versionPolicy, name }));
+  }
+  {
+    const versionPolicy = {
+      lockstep: false,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
+    const name = 'foo';
+    assert(shouldSync({ versionPolicy, name }));
+  }
+  {
+    const versionPolicy = {
+      lockstep: true,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
     const name = 'bar';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -1983,7 +2119,7 @@ async function testVersionOnboarding() {
       ],
     };
     const name = 'bar';
-    assert(!shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const name = 'foo';
@@ -2000,7 +2136,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^1.0.0');
+    assert.equal(getVersion({ name, deps }), '^1.0.0');
   }
   {
     const name = 'foo';
@@ -2039,7 +2175,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^2.0.0');
+    assert.equal(getVersion({ name, deps }), '^2.0.0');
   }
   {
     const name = 'foo';
@@ -2067,7 +2203,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '~1.0.0');
+    assert.equal(getVersion({ name, deps }), '~1.0.0');
   }
   {
     const name = 'foo';
@@ -2106,7 +2242,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^2.0.0'); // do not use 'resolutions' version
+    assert.equal(getVersion({ name, deps }), '^2.0.0'); // do not use 'resolutions' version
   }
 }
 
@@ -2124,7 +2260,7 @@ async function testYarnCommands() {
   ];
   const root = `${tmp}/tmp/yarn-commands`;
 
-  await install({root, cwd: `${root}/a`});
+  await install({ root, cwd: `${root}/a` });
 
   // build
   const buildStreamFile = `${tmp}/tmp/yarn-commands/build-stream.txt`;
@@ -2214,7 +2350,7 @@ async function testCommand() {
   const streamFile = `${tmp}/tmp/bin/stream.txt`;
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
-  await exec(`${jazelle}`, {cwd}, [stream, stream]);
+  await exec(`${jazelle}`, { cwd }, [stream, stream]);
   assert((await read(streamFile, 'utf8')).includes('Usage: jazelle [command]'));
 }
 
@@ -2228,13 +2364,13 @@ async function testYarnCommand() {
   const yarnStreamFile = `${tmp}/tmp/bin/yarn-stream.txt`;
   const yarnStream = createWriteStream(yarnStreamFile);
   await new Promise(resolve => yarnStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version --cwd a`, {cwd}, [yarnStream]);
+  await exec(`${jazelle} yarn --version --cwd a`, { cwd }, [yarnStream]);
   assert((await read(yarnStreamFile, 'utf8')).includes('.'));
 
   const cwdStreamFile = `${tmp}/tmp/bin/cwd-stream.txt`;
   const cwdStream = createWriteStream(cwdStreamFile);
   await new Promise(resolve => cwdStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version`, {cwd: `${cwd}/a`}, [cwdStream]);
+  await exec(`${jazelle} yarn --version`, { cwd: `${cwd}/a` }, [cwdStream]);
   assert((await read(cwdStreamFile, 'utf8')).includes('.'));
 }
 
@@ -2248,7 +2384,7 @@ async function testBazelCommand() {
   const bazelStreamFile = `${tmp}/tmp/bin/bazel-stream.txt`;
   const bazelStream = createWriteStream(bazelStreamFile);
   await new Promise(resolve => bazelStream.on('open', resolve));
-  await exec(`${jazelle} bazel version`, {cwd}, [bazelStream]);
+  await exec(`${jazelle} bazel version`, { cwd }, [bazelStream]);
   assert((await read(bazelStreamFile, 'utf8')).includes('Build label:'));
 }
 
@@ -2273,7 +2409,7 @@ async function testDevCommand() {
   const devStream = createWriteStream(devStreamFile);
   await new Promise(resolve => devStream.on('open', resolve));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
   await spawn('./test-sigint.sh', [], {
     env: {
@@ -2314,9 +2450,9 @@ async function testStartCommand() {
   const startStream = createWriteStream(startStreamFile);
   await new Promise(resolve => startStream.on('open', resolve));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
-  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
+  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
   assert((await read(startStreamFile, 'utf8')).includes('\nstart\n'));
 }
 
@@ -2346,9 +2482,9 @@ async function testBazelDependentBuilds() {
   assert((await read(b)).includes('module.exports = 111'));
   assert((await read(a)).includes('require(\\"b\\") + require(\\"c\\")'));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
-  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
+  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
   assert.equal(await read(startStreamFile, 'utf8'), '333\n');
   assert(await exists(`${cwd}/a/foo/foo.js`));
   assert(await exists(`${cwd}/b/compiled/foo.js`));
@@ -2377,11 +2513,11 @@ async function testBazelDependentFailure() {
   const c = `${cwd}/c/package.json`;
   assert((await read(c, 'utf8')).includes('mkdir -p dist && mkdir dist'));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream, startStream])
+    exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream, startStream])
   );
 }
 
@@ -2444,7 +2580,7 @@ async function testLocalize() {
   await exec(cmd);
 
   const root = `${tmp}/tmp/localize`;
-  await localize({root});
+  await localize({ root });
   const meta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   assert.equal(meta.dependencies.a, '0.0.0-monorepo');
   assert.equal(meta.devDependencies.a, '0.0.0-monorepo');
@@ -2477,7 +2613,7 @@ async function testCheck() {
   );
 
   // Check with --all
-  result = await check({root, json: true, all: true});
+  result = await check({ root, json: true, all: true });
   if (!result) {
     assert.ok(result);
     return;
@@ -2510,7 +2646,7 @@ async function testOutdated() {
   const root = `${tmp}/tmp/outdated`;
 
   // Sanity check
-  await outdated({root, logger});
+  await outdated({ root, logger });
 
   // helper function to sort an array of objects by their
   // 'packageName' property.
@@ -2534,7 +2670,7 @@ async function testOutdated() {
   flush();
 
   // Test --dedup option
-  await outdated({root, logger, dedup: true});
+  await outdated({ root, logger, dedup: true });
   data.sort();
   assert.equal(data[0], 'only-version-one-zero-zero 0.1.0 0.2.0 1.0.0');
   assert.equal(data[1].substring(0, 'semver ^6.2.0 '.length), 'semver ^6.2.0 ');
@@ -2546,7 +2682,7 @@ async function testOutdated() {
 
   // Test --json option w/out --dedup
   {
-    await outdated({root, logger, json: true, dedup: false});
+    await outdated({ root, logger, json: true, dedup: false });
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
@@ -2591,7 +2727,7 @@ async function testOutdated() {
 
   // Test --json option w/ --dedup
   {
-    await outdated({root, logger, json: true, dedup: true});
+    await outdated({ root, logger, json: true, dedup: true });
 
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
@@ -2638,9 +2774,9 @@ async function testShouldInstall() {
   const root = `${tmp}/tmp/should-install`;
 
   // should bypass yarn install due to bool_shouldinstall
-  await install({root, cwd: root});
+  await install({ root, cwd: root });
   assert.equal(await read(`${root}/yarn.lock`), '');
 
-  await focus({root, cwd: root, packages: ['a']});
+  await focus({ root, cwd: root, packages: ['a'] });
   assert.equal(await read(`${root}/yarn.lock`), '');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,14 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@inquirer/external-editor@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz#dc16e7064c46c53be09918db639ff780718c071a"
+  integrity sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==
+  dependencies:
+    chardet "^2.1.0"
+    iconv-lite "^0.7.0"
+
 "@rauschma/stringio@1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@rauschma/stringio/-/stringio-1.4.0.tgz#0b667bea726652a10a48dfc1dadc89e0ec51e269"
@@ -149,7 +157,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -185,6 +193,20 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -192,6 +214,14 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -215,10 +245,23 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chardet@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz#1007f441a1ae9f9199a4a67f6e978fb0aa9aa3fe"
+  integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -227,10 +270,20 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.5.0:
+  version "2.9.2"
+  resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
+
 cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -283,6 +336,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+defaults@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
+  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
+  dependencies:
+    clone "^1.0.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -570,6 +630,18 @@ iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz#c50cd80e6746ca8115eb98743afa81aa0e147a3e"
+  integrity sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
@@ -596,7 +668,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -619,6 +691,27 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
+
+inquirer@^8.2.6:
+  version "8.2.7"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz#62f6b931a9b7f8735dc42db927316d8fb6f71de8"
+  integrity sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==
+  dependencies:
+    "@inquirer/external-editor" "^1.0.0"
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^6.0.1"
 
 is-core-module@^2.1.0:
   version "2.1.0"
@@ -648,6 +741,16 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -694,6 +797,19 @@ lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -765,6 +881,21 @@ optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -819,6 +950,15 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -864,7 +1004,19 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-"safer-buffer@>= 2.1.2 < 3":
+rxjs@^7.5.5:
+  version "7.8.2"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -932,6 +1084,13 @@ string-width@^4.1.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -1003,6 +1162,11 @@ tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -1027,10 +1191,22 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
 
 which@^1.2.9:
   version "1.3.1"
@@ -1043,6 +1219,15 @@ word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wrap-ansi@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
Fork of https://github.com/uber-web/jazelle/pull/169

Changes include:
* Revert changes to `yarn.lock`
* Re-generate the lockfile making _only_ the changes required as a result of the dependency graph changing

---

To be abandoned in favor of #169 