### PR TITLE
Bump to version 0.0.0-standalone.103

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -1,16 +1,16 @@
 // @flow
-const { minVersion, satisfies, valid } = require('../utils/cached-semver');
-const { getManifest } = require('../utils/get-manifest.js');
-const { findLocalDependency } = require('../utils/find-local-dependency.js');
-const { read, write, spawn } = require('../utils/node-helpers.js');
-const { node, yarn } = require('../utils/binary-paths.js');
+const {minVersion, satisfies, valid} = require('../utils/cached-semver');
+const {getManifest} = require('../utils/get-manifest.js');
+const {findLocalDependency} = require('../utils/find-local-dependency.js');
+const {read, write, spawn} = require('../utils/node-helpers.js');
+const {node, yarn} = require('../utils/binary-paths.js');
 const {
   getTypesPackages,
   checkBundledTypes,
   findBestTypesVersion,
   removeTypesPackage,
 } = require('../utils/types-manager.js');
-const { promptForTypesVersion } = require('../utils/upgrade-prompts.js');
+const {promptForTypesVersion} = require('../utils/upgrade-prompts.js');
 
 /*::
 export type UpgradeArgs = {
@@ -27,8 +27,8 @@ type RemoveTypesPackage = (string, Array<string>) => Promise<void>;
 type PromptForTypesVersion = (string, ?string, Array<string>, boolean) => Promise<?string>;
 */
 
-const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
-  const { projects } = await getManifest({ root });
+const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
+  const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 
   // group by whether the dep is local (listed in manifest.json) or external (from registry)
@@ -36,9 +36,9 @@ const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
   const externals = [];
   for (const arg of args) {
     let [, name, version] = arg.match(/(@?[^@]*)@?(.*)/) || [];
-    const local = await findLocalDependency({ root, name });
-    if (local) locals.push({ local, name, version });
-    else externals.push({ name, range: version });
+    const local = await findLocalDependency({root, name});
+    if (local) locals.push({local, name, version});
+    else externals.push({name, range: version});
   }
 
   if (locals.length > 0) {
@@ -46,7 +46,7 @@ const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
       roots.map(async cwd => {
         const meta = JSON.parse(await read(`${cwd}/package.json`, 'utf8'));
 
-        for (const { local, name, version } of locals) {
+        for (const {local, name, version} of locals) {
           if (version && version !== local.meta.version) {
             const error = `You must use version ${name}@${local.meta.version}`;
             throw new Error(error);
@@ -68,22 +68,15 @@ const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
   }
 
   if (externals.length > 0) {
-    const deps = externals.map(({ name, range }) => {
+    const deps = externals.map(({name, range}) => {
       return name + (range ? `@${range}` : '');
     });
 
     // In non-interactive mode, skip prompting by returning null
-    const promptFn = interactive
-      ? promptForTypesVersion
-      : async () => null;
+    const promptFn = interactive ? promptForTypesVersion : async () => null;
 
     // Add @types packages
-    const typesDeps = await getTypesPackages(
-      externals,
-      root,
-      roots,
-      promptFn
-    );
+    const typesDeps = await getTypesPackages(externals, root, roots, promptFn);
 
     await spawn(
       node,

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -1,16 +1,16 @@
 // @flow
-const {minVersion, satisfies, valid} = require('../utils/cached-semver');
-const {getManifest} = require('../utils/get-manifest.js');
-const {findLocalDependency} = require('../utils/find-local-dependency.js');
-const {read, write, spawn} = require('../utils/node-helpers.js');
-const {node, yarn} = require('../utils/binary-paths.js');
+const { minVersion, satisfies, valid } = require('../utils/cached-semver');
+const { getManifest } = require('../utils/get-manifest.js');
+const { findLocalDependency } = require('../utils/find-local-dependency.js');
+const { read, write, spawn } = require('../utils/node-helpers.js');
+const { node, yarn } = require('../utils/binary-paths.js');
 const {
   getTypesPackages,
   checkBundledTypes,
   findBestTypesVersion,
   removeTypesPackage,
 } = require('../utils/types-manager.js');
-const {promptForTypesVersion} = require('../utils/upgrade-prompts.js');
+const { promptForTypesVersion } = require('../utils/upgrade-prompts.js');
 
 /*::
 export type UpgradeArgs = {
@@ -27,8 +27,8 @@ type RemoveTypesPackage = (string, Array<string>) => Promise<void>;
 type PromptForTypesVersion = (string, ?string, Array<string>, boolean) => Promise<?string>;
 */
 
-const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
-  const {projects} = await getManifest({root});
+const upgrade /*: Upgrade */ = async ({ root, args, interactive = true }) => {
+  const { projects } = await getManifest({ root });
   const roots = projects.map(dir => `${root}/${dir}`);
 
   // group by whether the dep is local (listed in manifest.json) or external (from registry)
@@ -36,9 +36,9 @@ const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
   const externals = [];
   for (const arg of args) {
     let [, name, version] = arg.match(/(@?[^@]*)@?(.*)/) || [];
-    const local = await findLocalDependency({root, name});
-    if (local) locals.push({local, name, version});
-    else externals.push({name, range: version});
+    const local = await findLocalDependency({ root, name });
+    if (local) locals.push({ local, name, version });
+    else externals.push({ name, range: version });
   }
 
   if (locals.length > 0) {
@@ -46,7 +46,7 @@ const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
       roots.map(async cwd => {
         const meta = JSON.parse(await read(`${cwd}/package.json`, 'utf8'));
 
-        for (const {local, name, version} of locals) {
+        for (const { local, name, version } of locals) {
           if (version && version !== local.meta.version) {
             const error = `You must use version ${name}@${local.meta.version}`;
             throw new Error(error);
@@ -68,16 +68,21 @@ const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
   }
 
   if (externals.length > 0) {
-    const deps = externals.map(({name, range}) => {
+    const deps = externals.map(({ name, range }) => {
       return name + (range ? `@${range}` : '');
     });
+
+    // In non-interactive mode, skip prompting by returning null
+    const promptFn = interactive
+      ? promptForTypesVersion
+      : async () => null;
 
     // Add @types packages
     const typesDeps = await getTypesPackages(
       externals,
       root,
       roots,
-      promptForTypesVersion
+      promptFn
     );
 
     await spawn(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.102",
+  "version": "0.0.0-standalone.103",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,34 +1,34 @@
 // @flow
 const assert = require('assert');
-const { tmpdir } = require('os');
+const {tmpdir} = require('os');
 const path = require('path');
-const { readFileSync, createWriteStream } = require('fs');
-const { runCLI } = require('../index');
-const { init } = require('../commands/init.js');
-const { scaffold } = require('../commands/scaffold.js');
-const { install, ImmutableInstallError } = require('../commands/install.js');
-const { add } = require('../commands/add.js');
-const { bazel: bazelCmd } = require('../commands/bazel.js');
-const { upgrade } = require('../commands/upgrade.js');
-const { remove } = require('../commands/remove.js');
-const { ci } = require('../commands/ci.js');
-const { focus } = require('../commands/focus.js');
-const { purge } = require('../commands/purge.js');
-const { node: nodeCmd } = require('../commands/node.js');
-const { yarn: yarnCmd } = require('../commands/yarn.js');
-const { bump } = require('../commands/bump.js');
-const { script } = require('../commands/script.js');
-const { localize } = require('../commands/localize.js');
-const { check } = require('../commands/check.js');
-const { outdated } = require('../commands/outdated.js');
+const {readFileSync, createWriteStream} = require('fs');
+const {runCLI} = require('../index');
+const {init} = require('../commands/init.js');
+const {scaffold} = require('../commands/scaffold.js');
+const {install, ImmutableInstallError} = require('../commands/install.js');
+const {add} = require('../commands/add.js');
+const {bazel: bazelCmd} = require('../commands/bazel.js');
+const {upgrade} = require('../commands/upgrade.js');
+const {remove} = require('../commands/remove.js');
+const {ci} = require('../commands/ci.js');
+const {focus} = require('../commands/focus.js');
+const {purge} = require('../commands/purge.js');
+const {node: nodeCmd} = require('../commands/node.js');
+const {yarn: yarnCmd} = require('../commands/yarn.js');
+const {bump} = require('../commands/bump.js');
+const {script} = require('../commands/script.js');
+const {localize} = require('../commands/localize.js');
+const {check} = require('../commands/check.js');
+const {outdated} = require('../commands/outdated.js');
 
-const { assertProjectDir } = require('../utils/assert-project-dir.js');
-const { batchTestGroup } = require('../utils/batch-test-group');
+const {assertProjectDir} = require('../utils/assert-project-dir.js');
+const {batchTestGroup} = require('../utils/batch-test-group');
 const bazelCmds = require('../utils/bazel-commands.js');
-const { bazel, node, yarn } = require('../utils/binary-paths.js');
-const { cli } = require('../utils/cli.js');
-const { detectCyclicDeps } = require('../utils/detect-cyclic-deps.js');
-const { copy } = require('../rules/untar');
+const {bazel, node, yarn} = require('../utils/binary-paths.js');
+const {cli} = require('../utils/cli.js');
+const {detectCyclicDeps} = require('../utils/detect-cyclic-deps.js');
+const {copy} = require('../rules/untar');
 const {
   exec,
   exists,
@@ -39,20 +39,20 @@ const {
   remove: rm,
   spawn,
 } = require('../utils/node-helpers.js');
-const { findChangedTargets } = require('../utils/find-changed-targets.js');
-const { findLocalDependency } = require('../utils/find-local-dependency.js');
+const {findChangedTargets} = require('../utils/find-changed-targets.js');
+const {findLocalDependency} = require('../utils/find-local-dependency.js');
 const {
   generateBazelBuildRules,
 } = require('../utils/generate-bazel-build-rules.js');
-const { generateBazelignore } = require('../utils/generate-bazelignore.js');
-const { getDownstreams } = require('../utils/get-downstreams.js');
-const { getManifest } = require('../utils/get-manifest.js');
-const { getLocalDependencies } = require('../utils/get-local-dependencies.js');
-const { getRootDir } = require('../utils/get-root-dir.js');
-const { getTestGroups } = require('../utils/get-test-groups.js');
-const { groupByDepsets } = require('../utils/group-by-depsets.js');
-const { isYarnResolution } = require('../utils/is-yarn-resolution.js');
-const { parse, getPassThroughArgs } = require('../utils/parse-argv.js');
+const {generateBazelignore} = require('../utils/generate-bazelignore.js');
+const {getDownstreams} = require('../utils/get-downstreams.js');
+const {getManifest} = require('../utils/get-manifest.js');
+const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
+const {getRootDir} = require('../utils/get-root-dir.js');
+const {getTestGroups} = require('../utils/get-test-groups.js');
+const {groupByDepsets} = require('../utils/group-by-depsets.js');
+const {isYarnResolution} = require('../utils/is-yarn-resolution.js');
+const {parse, getPassThroughArgs} = require('../utils/parse-argv.js');
 
 const {
   reportMismatchedTopLevelDeps,
@@ -63,9 +63,9 @@ const {
   removeCallArgItem,
   sortCallArgItems,
 } = require('../utils/starlark.js');
-const { shouldSync, getVersion } = require('../utils/version-onboarding.js');
+const {shouldSync, getVersion} = require('../utils/version-onboarding.js');
 const yarnCmds = require('../utils/yarn-commands.js');
-const { sortPackageJson } = require('../utils/sort-package-json');
+const {sortPackageJson} = require('../utils/sort-package-json');
 
 const originalProcessExit = process.exit;
 process.on('unhandledRejection', e => {
@@ -270,7 +270,7 @@ async function testBazel() {
 
   // @see: https://bazel.build/run/scripts#exit-codes
   await expectProcessExit(2, () =>
-    bazelCmd({ root, args: ['run'], stdio: ['ignore', stream, stream] })
+    bazelCmd({root, args: ['run'], stdio: ['ignore', stream, stream]})
   );
 
   const output = await read(streamFile, 'utf8');
@@ -280,7 +280,7 @@ async function testBazel() {
 
 async function testInit() {
   await exec(`mkdir ${tmp}/tmp/init`);
-  await init({ cwd: `${tmp}/tmp/init` });
+  await init({cwd: `${tmp}/tmp/init`});
   assert(await exists(`${tmp}/tmp/init/WORKSPACE`));
   assert(await exists(`${tmp}/tmp/init/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/init/.bazelversion`));
@@ -299,7 +299,7 @@ async function testScaffold() {
   const from = 'template';
   const to = 'foo';
   const name = '@foo/foo';
-  await scaffold({ root, cwd, from, to, name });
+  await scaffold({root, cwd, from, to, name});
 
   assert(await exists(`${tmp}/tmp/scaffold/foo/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/scaffold/foo/package.json`));
@@ -314,11 +314,11 @@ async function testScaffold() {
   assert.equal(meta.name, '@foo/foo');
 
   const manifestFile = `${tmp}/tmp/scaffold/manifest.json`;
-  const { projects } = JSON.parse(await read(manifestFile, 'utf8'));
+  const {projects} = JSON.parse(await read(manifestFile, 'utf8'));
   assert(projects === undefined);
 
   const rootMeta = `${tmp}/tmp/scaffold/package.json`;
-  const { workspaces } = JSON.parse(await read(rootMeta, 'utf8'));
+  const {workspaces} = JSON.parse(await read(rootMeta, 'utf8'));
   assert(workspaces.includes('foo'));
 }
 
@@ -447,7 +447,7 @@ async function testUpgrade() {
   assert((await read(meta, 'utf8')).includes('"has": "1.0.3"'));
   assert((await read(lockfile, 'utf8')).includes('function-bind'));
 
-  await upgrade({ root: `${tmp}/tmp/upgrade`, args: ['b'], interactive: false });
+  await upgrade({root: `${tmp}/tmp/upgrade`, args: ['b'], interactive: false});
   assert((await read(meta, 'utf8')).includes('"b": "1.0.0"'));
 }
 
@@ -544,7 +544,7 @@ async function testUpgradeTypesInteractiveMode() {
   const testRoot = `${tmp}/tmp/upgrade-types-interactive-mode`;
   await exec(`cp -r ${__dirname}/fixtures/upgrade-types/ ${testRoot}`);
 
-  const { promptForTypesVersion } = require('../commands/upgrade.js');
+  const {promptForTypesVersion} = require('../commands/upgrade.js');
 
   // Test non-interactive mode (interactive tests require stdin mocking - skip for now)
   const result = await promptForTypesVersion(
@@ -563,7 +563,7 @@ async function testUpgradeTypesInteractiveMode() {
 
 async function testPurge() {
   await exec(`cp -r ${__dirname}/fixtures/purge/ ${tmp}/tmp/purge`);
-  await purge({ root: `${tmp}/tmp/purge`, force: false });
+  await purge({root: `${tmp}/tmp/purge`, force: false});
   const nodeModules = `${tmp}/tmp/purge/a/node_modules`;
   const globalNodeModules = `${tmp}/tmp/purge/node_modules`;
   const temp = `${__dirname}/third_party/jazelle/temp`;
@@ -600,7 +600,7 @@ async function testNode() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({ root, cwd });
+  await install({root, cwd});
 
   await nodeCmd({
     root,
@@ -635,7 +635,7 @@ async function testYarn() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({ root, cwd });
+  await install({root, cwd});
 
   await yarnCmd({
     cwd,
@@ -665,8 +665,8 @@ async function testEach() {
   const root = `${tmp}/tmp/each`;
 
   const plan = [
-    { type: 'dir', dir: 'a', action: 'exec', args: ['foo'] },
-    { type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD'] },
+    {type: 'dir', dir: 'a', action: 'exec', args: ['foo']},
+    {type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD']},
   ];
   const failed = /*:: await */ await batchTestGroup({
     root,
@@ -691,17 +691,17 @@ async function testBump() {
   // do not update package.json files in CI
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    bump({ root, cwd, type: 'preminor', frozenPackageJson: true })
+    bump({root, cwd, type: 'preminor', frozenPackageJson: true})
   );
   assert(JSON.parse(await read(pkgMeta)).version, '0.0.0');
   assert(JSON.parse(await read(depMeta)).version, '0.0.0');
 
-  await bump({ root, cwd, type: 'preminor' });
+  await bump({root, cwd, type: 'preminor'});
   assert(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert(JSON.parse(await read(depMeta)).version, '0.1.0-0');
 
   // command should be idempotent
-  await bump({ root, cwd, type: 'preminor' });
+  await bump({root, cwd, type: 'preminor'});
   assert.equal(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert.equal(JSON.parse(await read(depMeta)).version, '0.0.0');
 
@@ -729,7 +729,7 @@ async function testScriptCommand() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({ root, cwd });
+  await install({root, cwd});
 
   await script({
     root,
@@ -758,11 +758,11 @@ async function testAssertProjectDir() {
   const dir1 = `${__dirname}/fixtures/project-dir`;
   const t = () => true;
   const f = () => false;
-  const result1 = await assertProjectDir({ dir: dir1 }).then(t, f);
+  const result1 = await assertProjectDir({dir: dir1}).then(t, f);
   assert(result1);
 
   const dir2 = `${__dirname}/fixtures/not-project-dir`;
-  const result2 = await assertProjectDir({ dir: dir2 }).then(f, t);
+  const result2 = await assertProjectDir({dir: dir2}).then(f, t);
   assert(result2);
 }
 
@@ -789,14 +789,14 @@ async function testBatchTestGroup() {
     root: `${tmp}/tmp/batch-test-group`,
     data: [
       [
-        { type: 'bazel', dir: 'a', action: 'flow', args: [] },
-        { type: 'bazel', dir: 'a', action: 'lint', args: [] },
-        { type: 'bazel', dir: 'a', action: 'test', args: [] },
+        {type: 'bazel', dir: 'a', action: 'flow', args: []},
+        {type: 'bazel', dir: 'a', action: 'lint', args: []},
+        {type: 'bazel', dir: 'a', action: 'test', args: []},
       ],
       [
-        { type: 'bazel', dir: 'b', action: 'lint', args: [] },
-        { type: 'bazel', dir: 'b', action: 'test', args: [] },
-        { type: 'bazel', dir: 'c', action: 'test', args: [] },
+        {type: 'bazel', dir: 'b', action: 'lint', args: []},
+        {type: 'bazel', dir: 'b', action: 'test', args: []},
+        {type: 'bazel', dir: 'c', action: 'test', args: []},
       ],
     ],
     index: 0,
@@ -982,12 +982,12 @@ async function testCLI() {
       `Foo
 
       --bar [bar]     bar`,
-      async ({ bar }) => {
+      async ({bar}) => {
         called = bar;
       },
     ],
   };
-  cli('foo', { bar: '1' }, cmds, async () => { });
+  cli('foo', {bar: '1'}, cmds, async () => {});
   assert.equal(called, '1');
 }
 
@@ -1078,7 +1078,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/dirs`;
     const files = `${__dirname}/fixtures/find-changed-targets/dirs/changes.txt`;
-    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
+    const dirs = await findChangedTargets({root, files, format: 'dirs'});
     assert.deepEqual(dirs, ['b', 'a']);
   }
   {
@@ -1101,7 +1101,7 @@ async function testFindChangedTargets() {
       root: `${tmp}/tmp/find-changed-targets/bazel`,
       cwd: `${tmp}/tmp/find-changed-targets/bazel`,
     });
-    const targets = await findChangedTargets({ root, files, format: 'targets' });
+    const targets = await findChangedTargets({root, files, format: 'targets'});
     assert.deepEqual(
       targets.sort(),
       [
@@ -1153,7 +1153,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/no-target`;
     const files = `${__dirname}/fixtures/find-changed-targets/no-target/changes.txt`;
-    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
+    const dirs = await findChangedTargets({root, files, format: 'dirs'});
     assert.deepEqual(dirs, []);
   }
 }
@@ -1184,7 +1184,7 @@ async function testImmutableInstall() {
     await exec(`cp -r ${fixturePath}/ ${root}`);
 
     try {
-      await install({ root, cwd: root, immutable: true });
+      await install({root, cwd: root, immutable: true});
       // $FlowFixMe: bad libdef?
       assert.fail('install should not succeed');
     } catch (error) {
@@ -1205,7 +1205,7 @@ async function testImmutableInstall() {
           // compare file with the original fixture file
           assert(
             (await read(`${root}/${file}`, 'utf-8')) ===
-            (await read(`${fixturePath}/${file}`, 'utf-8')),
+              (await read(`${fixturePath}/${file}`, 'utf-8')),
             `${file} should not have been changed`
           );
         } else {
@@ -1225,10 +1225,10 @@ async function testImmutableInstall() {
 
     // first run an install without `immutable` to prime the fixture
     // with all the generated files
-    await install({ root, cwd: root });
+    await install({root, cwd: root});
 
     try {
-      await install({ root, cwd: root, immutable: true });
+      await install({root, cwd: root, immutable: true});
     } catch (error) {
       // $FlowFixMe: bad libdef?
       assert.fail('install should succeed');
@@ -1343,7 +1343,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'a',
         version: '0.0.0',
-        dependencies: { b: '0.0.0' }, // cyclical dep should not break test
+        dependencies: {b: '0.0.0'}, // cyclical dep should not break test
       },
       depth: 3,
     },
@@ -1352,7 +1352,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: { a: '0.0.0' },
+        dependencies: {a: '0.0.0'},
       },
       depth: 2,
     },
@@ -1361,12 +1361,12 @@ async function testGetDownstreams() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: { b: '0.0.0' },
+        dependencies: {b: '0.0.0'},
       },
       depth: 1,
     },
   ];
-  const downstreams = getDownstreams({ deps, dep: deps[0] });
+  const downstreams = getDownstreams({deps, dep: deps[0]});
   assert.deepEqual(downstreams, deps.slice(1));
 }
 
@@ -1385,7 +1385,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: { a: 'workspace:*' },
+        dependencies: {a: 'workspace:*'},
       },
       depth: 3,
     },
@@ -1394,7 +1394,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: { b: '0.0.0' },
+        dependencies: {b: '0.0.0'},
       },
       depth: 2,
     },
@@ -1403,7 +1403,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'd',
         version: '0.0.0',
-        dependencies: { a: '0.0.0' },
+        dependencies: {a: '0.0.0'},
       },
       depth: 2,
     },
@@ -1449,7 +1449,7 @@ async function testGetLocalDependencies() {
 
 async function testGetManifest() {
   assert.deepEqual(
-    await getManifest({ root: `${__dirname}/fixtures/get-all-project-paths` }),
+    await getManifest({root: `${__dirname}/fixtures/get-all-project-paths`}),
     {
       projects: ['path/to/a', 'path/to/b'],
       workspace: 'host',
@@ -1460,7 +1460,7 @@ async function testGetManifest() {
 
 async function testGetRootDir() {
   const dir = `${__dirname}/fixtures/get-root-dir/a`;
-  const result = getRootDir({ dir });
+  const result = getRootDir({dir});
   assert(result);
 }
 
@@ -1482,14 +1482,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByTwo, [
     [
-      { type: 'bazel', dir: 'a', action: 'test', args: [] },
-      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+      {type: 'bazel', dir: 'a', action: 'test', args: []},
+      {type: 'bazel', dir: 'a', action: 'lint', args: []},
+      {type: 'bazel', dir: 'a', action: 'flow', args: []},
     ],
     [
-      { type: 'bazel', dir: 'b', action: 'test', args: [] },
-      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'c', action: 'test', args: [] },
+      {type: 'bazel', dir: 'b', action: 'test', args: []},
+      {type: 'bazel', dir: 'b', action: 'lint', args: []},
+      {type: 'bazel', dir: 'c', action: 'test', args: []},
     ],
   ]);
 
@@ -1507,15 +1507,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByFour, [
     [
-      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+      {type: 'bazel', dir: 'a', action: 'lint', args: []},
+      {type: 'bazel', dir: 'a', action: 'flow', args: []},
     ],
-    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
+    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
     [
-      { type: 'bazel', dir: 'b', action: 'test', args: [] },
-      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+      {type: 'bazel', dir: 'b', action: 'test', args: []},
+      {type: 'bazel', dir: 'b', action: 'lint', args: []},
     ],
-    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
+    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
   ]);
 
   const bazelByEight = await getTestGroups({
@@ -1531,12 +1531,12 @@ async function testGetTestGroups() {
     nodes: 8,
   });
   assert.deepEqual(bazelByEight, [
-    [{ type: 'bazel', dir: 'a', action: 'flow', args: [] }],
-    [{ type: 'bazel', dir: 'a', action: 'lint', args: [] }],
-    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
-    [{ type: 'bazel', dir: 'b', action: 'lint', args: [] }],
-    [{ type: 'bazel', dir: 'b', action: 'test', args: [] }],
-    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
+    [{type: 'bazel', dir: 'a', action: 'flow', args: []}],
+    [{type: 'bazel', dir: 'a', action: 'lint', args: []}],
+    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
+    [{type: 'bazel', dir: 'b', action: 'lint', args: []}],
+    [{type: 'bazel', dir: 'b', action: 'test', args: []}],
+    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
   ]);
 
   const dirByTwo = await getTestGroups({
@@ -1546,14 +1546,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByTwo, [
     [
-      { type: 'dir', dir: 'a', action: 'test', args: [] },
-      { type: 'dir', dir: 'a', action: 'lint', args: [] },
-      { type: 'dir', dir: 'a', action: 'flow', args: [] },
+      {type: 'dir', dir: 'a', action: 'test', args: []},
+      {type: 'dir', dir: 'a', action: 'lint', args: []},
+      {type: 'dir', dir: 'a', action: 'flow', args: []},
     ],
     [
-      { type: 'dir', dir: 'b', action: 'test', args: [] },
-      { type: 'dir', dir: 'b', action: 'lint', args: [] },
-      { type: 'dir', dir: 'c', action: 'test', args: [] },
+      {type: 'dir', dir: 'b', action: 'test', args: []},
+      {type: 'dir', dir: 'b', action: 'lint', args: []},
+      {type: 'dir', dir: 'c', action: 'test', args: []},
     ],
   ]);
 
@@ -1564,15 +1564,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByFour, [
     [
-      { type: 'dir', dir: 'a', action: 'lint', args: [] },
-      { type: 'dir', dir: 'a', action: 'flow', args: [] },
+      {type: 'dir', dir: 'a', action: 'lint', args: []},
+      {type: 'dir', dir: 'a', action: 'flow', args: []},
     ],
-    [{ type: 'dir', dir: 'a', action: 'test', args: [] }],
+    [{type: 'dir', dir: 'a', action: 'test', args: []}],
     [
-      { type: 'dir', dir: 'b', action: 'test', args: [] },
-      { type: 'dir', dir: 'b', action: 'lint', args: [] },
+      {type: 'dir', dir: 'b', action: 'test', args: []},
+      {type: 'dir', dir: 'b', action: 'lint', args: []},
     ],
-    [{ type: 'dir', dir: 'c', action: 'test', args: [] }],
+    [{type: 'dir', dir: 'c', action: 'test', args: []}],
   ]);
 }
 
@@ -1585,131 +1585,131 @@ async function testGroupByDepsets() {
   const bMeta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   const cMeta = JSON.parse(await read(`${root}/c/package.json`, 'utf8'));
   const metas = [
-    { dir: `${root}/a`, depth: 0, meta: aMeta },
-    { dir: `${root}/b`, depth: 0, meta: bMeta },
-    { dir: `${root}/c`, depth: 0, meta: cMeta },
+    {dir: `${root}/a`, depth: 0, meta: aMeta},
+    {dir: `${root}/b`, depth: 0, meta: bMeta},
+    {dir: `${root}/c`, depth: 0, meta: cMeta},
   ];
   const group = [
-    { type: 'bazel', dir: 'a', action: 'test', args: [] },
-    { type: 'bazel', dir: 'a', action: 'lint', args: [] },
-    { type: 'bazel', dir: 'a', action: 'flow', args: [] },
-    { type: 'bazel', dir: 'b', action: 'test', args: [] },
-    { type: 'bazel', dir: 'b', action: 'lint', args: [] },
-    { type: 'bazel', dir: 'b', action: 'flow', args: [] },
-    { type: 'bazel', dir: 'c', action: 'test', args: [] },
-    { type: 'bazel', dir: 'c', action: 'lint', args: [] },
-    { type: 'bazel', dir: 'c', action: 'flow', args: [] },
+    {type: 'bazel', dir: 'a', action: 'test', args: []},
+    {type: 'bazel', dir: 'a', action: 'lint', args: []},
+    {type: 'bazel', dir: 'a', action: 'flow', args: []},
+    {type: 'bazel', dir: 'b', action: 'test', args: []},
+    {type: 'bazel', dir: 'b', action: 'lint', args: []},
+    {type: 'bazel', dir: 'b', action: 'flow', args: []},
+    {type: 'bazel', dir: 'c', action: 'test', args: []},
+    {type: 'bazel', dir: 'c', action: 'lint', args: []},
+    {type: 'bazel', dir: 'c', action: 'flow', args: []},
   ];
-  assert.deepEqual(groupByDepsets({ root, metas, group }), [
+  assert.deepEqual(groupByDepsets({root, metas, group}), [
     [
-      { type: 'bazel', dir: 'a', action: 'test', args: [] },
-      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
-      { type: 'bazel', dir: 'b', action: 'test', args: [] },
-      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'b', action: 'flow', args: [] },
+      {type: 'bazel', dir: 'a', action: 'test', args: []},
+      {type: 'bazel', dir: 'a', action: 'lint', args: []},
+      {type: 'bazel', dir: 'a', action: 'flow', args: []},
+      {type: 'bazel', dir: 'b', action: 'test', args: []},
+      {type: 'bazel', dir: 'b', action: 'lint', args: []},
+      {type: 'bazel', dir: 'b', action: 'flow', args: []},
     ],
     [
-      { type: 'bazel', dir: 'c', action: 'test', args: [] },
-      { type: 'bazel', dir: 'c', action: 'lint', args: [] },
-      { type: 'bazel', dir: 'c', action: 'flow', args: [] },
+      {type: 'bazel', dir: 'c', action: 'test', args: []},
+      {type: 'bazel', dir: 'c', action: 'lint', args: []},
+      {type: 'bazel', dir: 'c', action: 'flow', args: []},
     ],
   ]);
 }
 
 async function testIsYarnResolution() {
   const exact = isYarnResolution({
-    meta: { resolutions: { a: '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {a: '0.0.0'}, name: '', version: ''},
     name: 'a',
   });
   assert.equal(exact, true);
 
   const namespaced = isYarnResolution({
-    meta: { resolutions: { '@a/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/b': '0.0.0'}, name: '', version: ''},
     name: '@a/b',
   });
   assert.equal(namespaced, true);
 
   const globbed = isYarnResolution({
-    meta: { resolutions: { '**/a': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'**/a': '0.0.0'}, name: '', version: ''},
     name: 'a',
   });
   assert.equal(globbed, true);
 
   const globbedNs = isYarnResolution({
-    meta: { resolutions: { '**/@a/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'**/@a/b': '0.0.0'}, name: '', version: ''},
     name: '@a/b',
   });
   assert.equal(globbedNs, true);
 
   const direct = isYarnResolution({
-    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
     name: 'b',
   });
   assert.equal(direct, true);
 
   const directNs = isYarnResolution({
-    meta: { resolutions: { 'a/@b/c': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/@b/c': '0.0.0'}, name: '', version: ''},
     name: '@b/c',
   });
   assert.equal(directNs, true);
 
   const directOfNs = isYarnResolution({
-    meta: { resolutions: { '@a/b/c': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/b/c': '0.0.0'}, name: '', version: ''},
     name: 'c',
   });
   assert.equal(directOfNs, true);
 
   const directNsOfNs = isYarnResolution({
-    meta: { resolutions: { '@a/b/@c/d': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/b/@c/d': '0.0.0'}, name: '', version: ''},
     name: '@c/d',
   });
   assert.equal(directNsOfNs, true);
 
   const transitive = isYarnResolution({
-    meta: { resolutions: { 'a/**/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/**/b': '0.0.0'}, name: '', version: ''},
     name: 'b',
   });
   assert.equal(transitive, true);
 
   const transitiveNs = isYarnResolution({
-    meta: { resolutions: { 'a/**/@b/c': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/**/@b/c': '0.0.0'}, name: '', version: ''},
     name: '@b/c',
   });
   assert.equal(transitiveNs, true);
 
   const transitiveOfNs = isYarnResolution({
-    meta: { resolutions: { '@a/b/**/c': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/b/**/c': '0.0.0'}, name: '', version: ''},
     name: 'c',
   });
   assert.equal(transitiveOfNs, true);
 
   const transitiveNsOfNs = isYarnResolution({
-    meta: { resolutions: { '@a/b/**/@c/d': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/b/**/@c/d': '0.0.0'}, name: '', version: ''},
     name: '@c/d',
   });
   assert.equal(transitiveNsOfNs, true);
 
   const nested = isYarnResolution({
-    meta: { resolutions: { 'a/b/c': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/b/c': '0.0.0'}, name: '', version: ''},
     name: 'c',
   });
   assert.equal(nested, true);
 
   const nestedOfNs = isYarnResolution({
-    meta: { resolutions: { 'a/@b/c/d': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/@b/c/d': '0.0.0'}, name: '', version: ''},
     name: 'd',
   });
   assert.equal(nestedOfNs, true);
 
   const positional = isYarnResolution({
-    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
     name: 'a',
   });
   assert.equal(positional, false);
 
   const positionalNs = isYarnResolution({
-    meta: { resolutions: { '@a/a/b': '0.0.0' }, name: '', version: '' },
+    meta: {resolutions: {'@a/a/b': '0.0.0'}, name: '', version: ''},
     name: 'a',
   });
   assert.equal(positionalNs, false);
@@ -1785,13 +1785,13 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutLockstep, {
     valid: false,
-    policy: { lockstep: false, exceptions: ['no-bugs', '@uber/mismatched'] },
+    policy: {lockstep: false, exceptions: ['no-bugs', '@uber/mismatched']},
     reported: {
       'no-bugs': {
         '^1.0.0': ['@uber/a', '@uber/b'],
         'npm:function-bind': ['@uber/c'],
       },
-      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
+      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
     },
   });
 
@@ -1805,9 +1805,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutPartialLockstep, {
     valid: false,
-    policy: { lockstep: false, exceptions: ['@uber/mismatched'] },
+    policy: {lockstep: false, exceptions: ['@uber/mismatched']},
     reported: {
-      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
+      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
     },
   });
 
@@ -1821,9 +1821,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withLockstep, {
     valid: false,
-    policy: { lockstep: true, exceptions: ['no-bugs'] },
+    policy: {lockstep: true, exceptions: ['no-bugs']},
     reported: {
-      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
+      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
     },
   });
 
@@ -1837,7 +1837,7 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withAllExceptions, {
     valid: true,
-    policy: { lockstep: true, exceptions: ['no-bugs', '@uber/mismatched'] },
+    policy: {lockstep: true, exceptions: ['no-bugs', '@uber/mismatched']},
     reported: {},
   });
 
@@ -1846,16 +1846,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
+      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
     },
   });
   assert.deepEqual(withVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: false,
-      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
+      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
     },
-    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
+    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
   });
 
   const withAllVersionedExceptions = await reportMismatchedTopLevelDeps({
@@ -1863,14 +1863,14 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
+      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
     },
   });
   assert.deepEqual(withAllVersionedExceptions, {
     valid: true,
     policy: {
       lockstep: false,
-      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
+      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
     },
     reported: {},
   });
@@ -1880,16 +1880,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: true,
-      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
+      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
     },
   });
   assert.deepEqual(withLockstepVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: true,
-      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
+      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
     },
-    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
+    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
   });
 
   const withLockstepAllVersionedExceptions = await reportMismatchedTopLevelDeps(
@@ -1900,7 +1900,7 @@ async function testReportMismatchedTopLevelDeps() {
         lockstep: true,
         exceptions: [
           'no-bugs',
-          { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
+          {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
         ],
       },
     }
@@ -1911,7 +1911,7 @@ async function testReportMismatchedTopLevelDeps() {
       lockstep: true,
       exceptions: [
         'no-bugs',
-        { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
+        {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
       ],
     },
     reported: {},
@@ -2021,7 +2021,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(!shouldSync({ versionPolicy, name }));
+    assert(!shouldSync({versionPolicy, name}));
   }
   {
     const versionPolicy = {
@@ -2029,7 +2029,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(shouldSync({ versionPolicy, name }));
+    assert(shouldSync({versionPolicy, name}));
   }
   {
     const versionPolicy = {
@@ -2037,7 +2037,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(shouldSync({ versionPolicy, name }));
+    assert(shouldSync({versionPolicy, name}));
   }
   {
     const versionPolicy = {
@@ -2045,33 +2045,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(!shouldSync({ versionPolicy, name }));
-  }
-  {
-    const versionPolicy = {
-      lockstep: true,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({ versionPolicy, name }));
-  }
-  {
-    const versionPolicy = {
-      lockstep: false,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({ versionPolicy, name }));
+    assert(!shouldSync({versionPolicy, name}));
   }
   {
     const versionPolicy = {
@@ -2083,8 +2057,34 @@ async function testVersionOnboarding() {
         },
       ],
     };
+    const name = 'foo';
+    assert(shouldSync({versionPolicy, name}));
+  }
+  {
+    const versionPolicy = {
+      lockstep: false,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
+    const name = 'foo';
+    assert(shouldSync({versionPolicy, name}));
+  }
+  {
+    const versionPolicy = {
+      lockstep: true,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
     const name = 'bar';
-    assert(shouldSync({ versionPolicy, name }));
+    assert(shouldSync({versionPolicy, name}));
   }
   {
     const versionPolicy = {
@@ -2097,7 +2097,7 @@ async function testVersionOnboarding() {
       ],
     };
     const name = 'bar';
-    assert(!shouldSync({ versionPolicy, name }));
+    assert(!shouldSync({versionPolicy, name}));
   }
   {
     const name = 'foo';
@@ -2114,7 +2114,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({ name, deps }), '^1.0.0');
+    assert.equal(getVersion({name, deps}), '^1.0.0');
   }
   {
     const name = 'foo';
@@ -2153,7 +2153,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({ name, deps }), '^2.0.0');
+    assert.equal(getVersion({name, deps}), '^2.0.0');
   }
   {
     const name = 'foo';
@@ -2181,7 +2181,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({ name, deps }), '~1.0.0');
+    assert.equal(getVersion({name, deps}), '~1.0.0');
   }
   {
     const name = 'foo';
@@ -2220,7 +2220,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({ name, deps }), '^2.0.0'); // do not use 'resolutions' version
+    assert.equal(getVersion({name, deps}), '^2.0.0'); // do not use 'resolutions' version
   }
 }
 
@@ -2238,7 +2238,7 @@ async function testYarnCommands() {
   ];
   const root = `${tmp}/tmp/yarn-commands`;
 
-  await install({ root, cwd: `${root}/a` });
+  await install({root, cwd: `${root}/a`});
 
   // build
   const buildStreamFile = `${tmp}/tmp/yarn-commands/build-stream.txt`;
@@ -2328,7 +2328,7 @@ async function testCommand() {
   const streamFile = `${tmp}/tmp/bin/stream.txt`;
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
-  await exec(`${jazelle}`, { cwd }, [stream, stream]);
+  await exec(`${jazelle}`, {cwd}, [stream, stream]);
   assert((await read(streamFile, 'utf8')).includes('Usage: jazelle [command]'));
 }
 
@@ -2342,13 +2342,13 @@ async function testYarnCommand() {
   const yarnStreamFile = `${tmp}/tmp/bin/yarn-stream.txt`;
   const yarnStream = createWriteStream(yarnStreamFile);
   await new Promise(resolve => yarnStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version --cwd a`, { cwd }, [yarnStream]);
+  await exec(`${jazelle} yarn --version --cwd a`, {cwd}, [yarnStream]);
   assert((await read(yarnStreamFile, 'utf8')).includes('.'));
 
   const cwdStreamFile = `${tmp}/tmp/bin/cwd-stream.txt`;
   const cwdStream = createWriteStream(cwdStreamFile);
   await new Promise(resolve => cwdStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version`, { cwd: `${cwd}/a` }, [cwdStream]);
+  await exec(`${jazelle} yarn --version`, {cwd: `${cwd}/a`}, [cwdStream]);
   assert((await read(cwdStreamFile, 'utf8')).includes('.'));
 }
 
@@ -2362,7 +2362,7 @@ async function testBazelCommand() {
   const bazelStreamFile = `${tmp}/tmp/bin/bazel-stream.txt`;
   const bazelStream = createWriteStream(bazelStreamFile);
   await new Promise(resolve => bazelStream.on('open', resolve));
-  await exec(`${jazelle} bazel version`, { cwd }, [bazelStream]);
+  await exec(`${jazelle} bazel version`, {cwd}, [bazelStream]);
   assert((await read(bazelStreamFile, 'utf8')).includes('Build label:'));
 }
 
@@ -2387,7 +2387,7 @@ async function testDevCommand() {
   const devStream = createWriteStream(devStreamFile);
   await new Promise(resolve => devStream.on('open', resolve));
 
-  await install({ root: cwd, cwd: `${cwd}/a` });
+  await install({root: cwd, cwd: `${cwd}/a`});
 
   await spawn('./test-sigint.sh', [], {
     env: {
@@ -2428,9 +2428,9 @@ async function testStartCommand() {
   const startStream = createWriteStream(startStreamFile);
   await new Promise(resolve => startStream.on('open', resolve));
 
-  await install({ root: cwd, cwd: `${cwd}/a` });
+  await install({root: cwd, cwd: `${cwd}/a`});
 
-  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
+  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
   assert((await read(startStreamFile, 'utf8')).includes('\nstart\n'));
 }
 
@@ -2460,9 +2460,9 @@ async function testBazelDependentBuilds() {
   assert((await read(b)).includes('module.exports = 111'));
   assert((await read(a)).includes('require(\\"b\\") + require(\\"c\\")'));
 
-  await install({ root: cwd, cwd: `${cwd}/a` });
+  await install({root: cwd, cwd: `${cwd}/a`});
 
-  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
+  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
   assert.equal(await read(startStreamFile, 'utf8'), '333\n');
   assert(await exists(`${cwd}/a/foo/foo.js`));
   assert(await exists(`${cwd}/b/compiled/foo.js`));
@@ -2491,11 +2491,11 @@ async function testBazelDependentFailure() {
   const c = `${cwd}/c/package.json`;
   assert((await read(c, 'utf8')).includes('mkdir -p dist && mkdir dist'));
 
-  await install({ root: cwd, cwd: `${cwd}/a` });
+  await install({root: cwd, cwd: `${cwd}/a`});
 
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream, startStream])
+    exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream, startStream])
   );
 }
 
@@ -2558,7 +2558,7 @@ async function testLocalize() {
   await exec(cmd);
 
   const root = `${tmp}/tmp/localize`;
-  await localize({ root });
+  await localize({root});
   const meta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   assert.equal(meta.dependencies.a, '0.0.0-monorepo');
   assert.equal(meta.devDependencies.a, '0.0.0-monorepo');
@@ -2591,7 +2591,7 @@ async function testCheck() {
   );
 
   // Check with --all
-  result = await check({ root, json: true, all: true });
+  result = await check({root, json: true, all: true});
   if (!result) {
     assert.ok(result);
     return;
@@ -2624,7 +2624,7 @@ async function testOutdated() {
   const root = `${tmp}/tmp/outdated`;
 
   // Sanity check
-  await outdated({ root, logger });
+  await outdated({root, logger});
 
   // helper function to sort an array of objects by their
   // 'packageName' property.
@@ -2648,7 +2648,7 @@ async function testOutdated() {
   flush();
 
   // Test --dedup option
-  await outdated({ root, logger, dedup: true });
+  await outdated({root, logger, dedup: true});
   data.sort();
   assert.equal(data[0], 'only-version-one-zero-zero 0.1.0 0.2.0 1.0.0');
   assert.equal(data[1].substring(0, 'semver ^6.2.0 '.length), 'semver ^6.2.0 ');
@@ -2660,7 +2660,7 @@ async function testOutdated() {
 
   // Test --json option w/out --dedup
   {
-    await outdated({ root, logger, json: true, dedup: false });
+    await outdated({root, logger, json: true, dedup: false});
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
@@ -2705,7 +2705,7 @@ async function testOutdated() {
 
   // Test --json option w/ --dedup
   {
-    await outdated({ root, logger, json: true, dedup: true });
+    await outdated({root, logger, json: true, dedup: true});
 
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
@@ -2752,9 +2752,9 @@ async function testShouldInstall() {
   const root = `${tmp}/tmp/should-install`;
 
   // should bypass yarn install due to bool_shouldinstall
-  await install({ root, cwd: root });
+  await install({root, cwd: root});
   assert.equal(await read(`${root}/yarn.lock`), '');
 
-  await focus({ root, cwd: root, packages: ['a'] });
+  await focus({root, cwd: root, packages: ['a']});
   assert.equal(await read(`${root}/yarn.lock`), '');
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,34 +1,34 @@
 // @flow
 const assert = require('assert');
-const {tmpdir} = require('os');
+const { tmpdir } = require('os');
 const path = require('path');
-const {readFileSync, createWriteStream} = require('fs');
-const {runCLI} = require('../index');
-const {init} = require('../commands/init.js');
-const {scaffold} = require('../commands/scaffold.js');
-const {install, ImmutableInstallError} = require('../commands/install.js');
-const {add} = require('../commands/add.js');
-const {bazel: bazelCmd} = require('../commands/bazel.js');
-const {upgrade} = require('../commands/upgrade.js');
-const {remove} = require('../commands/remove.js');
-const {ci} = require('../commands/ci.js');
-const {focus} = require('../commands/focus.js');
-const {purge} = require('../commands/purge.js');
-const {node: nodeCmd} = require('../commands/node.js');
-const {yarn: yarnCmd} = require('../commands/yarn.js');
-const {bump} = require('../commands/bump.js');
-const {script} = require('../commands/script.js');
-const {localize} = require('../commands/localize.js');
-const {check} = require('../commands/check.js');
-const {outdated} = require('../commands/outdated.js');
+const { readFileSync, createWriteStream } = require('fs');
+const { runCLI } = require('../index');
+const { init } = require('../commands/init.js');
+const { scaffold } = require('../commands/scaffold.js');
+const { install, ImmutableInstallError } = require('../commands/install.js');
+const { add } = require('../commands/add.js');
+const { bazel: bazelCmd } = require('../commands/bazel.js');
+const { upgrade } = require('../commands/upgrade.js');
+const { remove } = require('../commands/remove.js');
+const { ci } = require('../commands/ci.js');
+const { focus } = require('../commands/focus.js');
+const { purge } = require('../commands/purge.js');
+const { node: nodeCmd } = require('../commands/node.js');
+const { yarn: yarnCmd } = require('../commands/yarn.js');
+const { bump } = require('../commands/bump.js');
+const { script } = require('../commands/script.js');
+const { localize } = require('../commands/localize.js');
+const { check } = require('../commands/check.js');
+const { outdated } = require('../commands/outdated.js');
 
-const {assertProjectDir} = require('../utils/assert-project-dir.js');
-const {batchTestGroup} = require('../utils/batch-test-group');
+const { assertProjectDir } = require('../utils/assert-project-dir.js');
+const { batchTestGroup } = require('../utils/batch-test-group');
 const bazelCmds = require('../utils/bazel-commands.js');
-const {bazel, node, yarn} = require('../utils/binary-paths.js');
-const {cli} = require('../utils/cli.js');
-const {detectCyclicDeps} = require('../utils/detect-cyclic-deps.js');
-const {copy} = require('../rules/untar');
+const { bazel, node, yarn } = require('../utils/binary-paths.js');
+const { cli } = require('../utils/cli.js');
+const { detectCyclicDeps } = require('../utils/detect-cyclic-deps.js');
+const { copy } = require('../rules/untar');
 const {
   exec,
   exists,
@@ -39,20 +39,20 @@ const {
   remove: rm,
   spawn,
 } = require('../utils/node-helpers.js');
-const {findChangedTargets} = require('../utils/find-changed-targets.js');
-const {findLocalDependency} = require('../utils/find-local-dependency.js');
+const { findChangedTargets } = require('../utils/find-changed-targets.js');
+const { findLocalDependency } = require('../utils/find-local-dependency.js');
 const {
   generateBazelBuildRules,
 } = require('../utils/generate-bazel-build-rules.js');
-const {generateBazelignore} = require('../utils/generate-bazelignore.js');
-const {getDownstreams} = require('../utils/get-downstreams.js');
-const {getManifest} = require('../utils/get-manifest.js');
-const {getLocalDependencies} = require('../utils/get-local-dependencies.js');
-const {getRootDir} = require('../utils/get-root-dir.js');
-const {getTestGroups} = require('../utils/get-test-groups.js');
-const {groupByDepsets} = require('../utils/group-by-depsets.js');
-const {isYarnResolution} = require('../utils/is-yarn-resolution.js');
-const {parse, getPassThroughArgs} = require('../utils/parse-argv.js');
+const { generateBazelignore } = require('../utils/generate-bazelignore.js');
+const { getDownstreams } = require('../utils/get-downstreams.js');
+const { getManifest } = require('../utils/get-manifest.js');
+const { getLocalDependencies } = require('../utils/get-local-dependencies.js');
+const { getRootDir } = require('../utils/get-root-dir.js');
+const { getTestGroups } = require('../utils/get-test-groups.js');
+const { groupByDepsets } = require('../utils/group-by-depsets.js');
+const { isYarnResolution } = require('../utils/is-yarn-resolution.js');
+const { parse, getPassThroughArgs } = require('../utils/parse-argv.js');
 
 const {
   reportMismatchedTopLevelDeps,
@@ -63,9 +63,9 @@ const {
   removeCallArgItem,
   sortCallArgItems,
 } = require('../utils/starlark.js');
-const {shouldSync, getVersion} = require('../utils/version-onboarding.js');
+const { shouldSync, getVersion } = require('../utils/version-onboarding.js');
 const yarnCmds = require('../utils/yarn-commands.js');
-const {sortPackageJson} = require('../utils/sort-package-json');
+const { sortPackageJson } = require('../utils/sort-package-json');
 
 const originalProcessExit = process.exit;
 process.on('unhandledRejection', e => {
@@ -270,7 +270,7 @@ async function testBazel() {
 
   // @see: https://bazel.build/run/scripts#exit-codes
   await expectProcessExit(2, () =>
-    bazelCmd({root, args: ['run'], stdio: ['ignore', stream, stream]})
+    bazelCmd({ root, args: ['run'], stdio: ['ignore', stream, stream] })
   );
 
   const output = await read(streamFile, 'utf8');
@@ -280,7 +280,7 @@ async function testBazel() {
 
 async function testInit() {
   await exec(`mkdir ${tmp}/tmp/init`);
-  await init({cwd: `${tmp}/tmp/init`});
+  await init({ cwd: `${tmp}/tmp/init` });
   assert(await exists(`${tmp}/tmp/init/WORKSPACE`));
   assert(await exists(`${tmp}/tmp/init/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/init/.bazelversion`));
@@ -299,7 +299,7 @@ async function testScaffold() {
   const from = 'template';
   const to = 'foo';
   const name = '@foo/foo';
-  await scaffold({root, cwd, from, to, name});
+  await scaffold({ root, cwd, from, to, name });
 
   assert(await exists(`${tmp}/tmp/scaffold/foo/BUILD.bazel`));
   assert(await exists(`${tmp}/tmp/scaffold/foo/package.json`));
@@ -314,11 +314,11 @@ async function testScaffold() {
   assert.equal(meta.name, '@foo/foo');
 
   const manifestFile = `${tmp}/tmp/scaffold/manifest.json`;
-  const {projects} = JSON.parse(await read(manifestFile, 'utf8'));
+  const { projects } = JSON.parse(await read(manifestFile, 'utf8'));
   assert(projects === undefined);
 
   const rootMeta = `${tmp}/tmp/scaffold/package.json`;
-  const {workspaces} = JSON.parse(await read(rootMeta, 'utf8'));
+  const { workspaces } = JSON.parse(await read(rootMeta, 'utf8'));
   assert(workspaces.includes('foo'));
 }
 
@@ -447,7 +447,7 @@ async function testUpgrade() {
   assert((await read(meta, 'utf8')).includes('"has": "1.0.3"'));
   assert((await read(lockfile, 'utf8')).includes('function-bind'));
 
-  await upgrade({root: `${tmp}/tmp/upgrade`, args: ['b'], interactive: false});
+  await upgrade({ root: `${tmp}/tmp/upgrade`, args: ['b'], interactive: false });
   assert((await read(meta, 'utf8')).includes('"b": "1.0.0"'));
 }
 
@@ -544,7 +544,7 @@ async function testUpgradeTypesInteractiveMode() {
   const testRoot = `${tmp}/tmp/upgrade-types-interactive-mode`;
   await exec(`cp -r ${__dirname}/fixtures/upgrade-types/ ${testRoot}`);
 
-  const {promptForTypesVersion} = require('../commands/upgrade.js');
+  const { promptForTypesVersion } = require('../commands/upgrade.js');
 
   // Test non-interactive mode (interactive tests require stdin mocking - skip for now)
   const result = await promptForTypesVersion(
@@ -563,7 +563,7 @@ async function testUpgradeTypesInteractiveMode() {
 
 async function testPurge() {
   await exec(`cp -r ${__dirname}/fixtures/purge/ ${tmp}/tmp/purge`);
-  await purge({root: `${tmp}/tmp/purge`, force: false});
+  await purge({ root: `${tmp}/tmp/purge`, force: false });
   const nodeModules = `${tmp}/tmp/purge/a/node_modules`;
   const globalNodeModules = `${tmp}/tmp/purge/node_modules`;
   const temp = `${__dirname}/third_party/jazelle/temp`;
@@ -600,7 +600,7 @@ async function testNode() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await nodeCmd({
     root,
@@ -635,7 +635,7 @@ async function testYarn() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await yarnCmd({
     cwd,
@@ -665,8 +665,8 @@ async function testEach() {
   const root = `${tmp}/tmp/each`;
 
   const plan = [
-    {type: 'dir', dir: 'a', action: 'exec', args: ['foo']},
-    {type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD']},
+    { type: 'dir', dir: 'a', action: 'exec', args: ['foo'] },
+    { type: 'dir', dir: 'a', action: 'exec', args: ['bash', '-c', 'echo $PWD'] },
   ];
   const failed = /*:: await */ await batchTestGroup({
     root,
@@ -691,17 +691,17 @@ async function testBump() {
   // do not update package.json files in CI
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    bump({root, cwd, type: 'preminor', frozenPackageJson: true})
+    bump({ root, cwd, type: 'preminor', frozenPackageJson: true })
   );
   assert(JSON.parse(await read(pkgMeta)).version, '0.0.0');
   assert(JSON.parse(await read(depMeta)).version, '0.0.0');
 
-  await bump({root, cwd, type: 'preminor'});
+  await bump({ root, cwd, type: 'preminor' });
   assert(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert(JSON.parse(await read(depMeta)).version, '0.1.0-0');
 
   // command should be idempotent
-  await bump({root, cwd, type: 'preminor'});
+  await bump({ root, cwd, type: 'preminor' });
   assert.equal(JSON.parse(await read(pkgMeta)).version, '0.1.0-0');
   assert.equal(JSON.parse(await read(depMeta)).version, '0.0.0');
 
@@ -729,7 +729,7 @@ async function testScriptCommand() {
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
 
-  await install({root, cwd});
+  await install({ root, cwd });
 
   await script({
     root,
@@ -758,11 +758,11 @@ async function testAssertProjectDir() {
   const dir1 = `${__dirname}/fixtures/project-dir`;
   const t = () => true;
   const f = () => false;
-  const result1 = await assertProjectDir({dir: dir1}).then(t, f);
+  const result1 = await assertProjectDir({ dir: dir1 }).then(t, f);
   assert(result1);
 
   const dir2 = `${__dirname}/fixtures/not-project-dir`;
-  const result2 = await assertProjectDir({dir: dir2}).then(f, t);
+  const result2 = await assertProjectDir({ dir: dir2 }).then(f, t);
   assert(result2);
 }
 
@@ -789,14 +789,14 @@ async function testBatchTestGroup() {
     root: `${tmp}/tmp/batch-test-group`,
     data: [
       [
-        {type: 'bazel', dir: 'a', action: 'flow', args: []},
-        {type: 'bazel', dir: 'a', action: 'lint', args: []},
-        {type: 'bazel', dir: 'a', action: 'test', args: []},
+        { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+        { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+        { type: 'bazel', dir: 'a', action: 'test', args: [] },
       ],
       [
-        {type: 'bazel', dir: 'b', action: 'lint', args: []},
-        {type: 'bazel', dir: 'b', action: 'test', args: []},
-        {type: 'bazel', dir: 'c', action: 'test', args: []},
+        { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+        { type: 'bazel', dir: 'b', action: 'test', args: [] },
+        { type: 'bazel', dir: 'c', action: 'test', args: [] },
       ],
     ],
     index: 0,
@@ -982,12 +982,12 @@ async function testCLI() {
       `Foo
 
       --bar [bar]     bar`,
-      async ({bar}) => {
+      async ({ bar }) => {
         called = bar;
       },
     ],
   };
-  cli('foo', {bar: '1'}, cmds, async () => {});
+  cli('foo', { bar: '1' }, cmds, async () => { });
   assert.equal(called, '1');
 }
 
@@ -1078,7 +1078,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/dirs`;
     const files = `${__dirname}/fixtures/find-changed-targets/dirs/changes.txt`;
-    const dirs = await findChangedTargets({root, files, format: 'dirs'});
+    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
     assert.deepEqual(dirs, ['b', 'a']);
   }
   {
@@ -1101,7 +1101,7 @@ async function testFindChangedTargets() {
       root: `${tmp}/tmp/find-changed-targets/bazel`,
       cwd: `${tmp}/tmp/find-changed-targets/bazel`,
     });
-    const targets = await findChangedTargets({root, files, format: 'targets'});
+    const targets = await findChangedTargets({ root, files, format: 'targets' });
     assert.deepEqual(
       targets.sort(),
       [
@@ -1153,7 +1153,7 @@ async function testFindChangedTargets() {
   {
     const root = `${__dirname}/fixtures/find-changed-targets/no-target`;
     const files = `${__dirname}/fixtures/find-changed-targets/no-target/changes.txt`;
-    const dirs = await findChangedTargets({root, files, format: 'dirs'});
+    const dirs = await findChangedTargets({ root, files, format: 'dirs' });
     assert.deepEqual(dirs, []);
   }
 }
@@ -1184,7 +1184,7 @@ async function testImmutableInstall() {
     await exec(`cp -r ${fixturePath}/ ${root}`);
 
     try {
-      await install({root, cwd: root, immutable: true});
+      await install({ root, cwd: root, immutable: true });
       // $FlowFixMe: bad libdef?
       assert.fail('install should not succeed');
     } catch (error) {
@@ -1205,7 +1205,7 @@ async function testImmutableInstall() {
           // compare file with the original fixture file
           assert(
             (await read(`${root}/${file}`, 'utf-8')) ===
-              (await read(`${fixturePath}/${file}`, 'utf-8')),
+            (await read(`${fixturePath}/${file}`, 'utf-8')),
             `${file} should not have been changed`
           );
         } else {
@@ -1225,10 +1225,10 @@ async function testImmutableInstall() {
 
     // first run an install without `immutable` to prime the fixture
     // with all the generated files
-    await install({root, cwd: root});
+    await install({ root, cwd: root });
 
     try {
-      await install({root, cwd: root, immutable: true});
+      await install({ root, cwd: root, immutable: true });
     } catch (error) {
       // $FlowFixMe: bad libdef?
       assert.fail('install should succeed');
@@ -1343,7 +1343,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'a',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'}, // cyclical dep should not break test
+        dependencies: { b: '0.0.0' }, // cyclical dep should not break test
       },
       depth: 3,
     },
@@ -1352,7 +1352,7 @@ async function testGetDownstreams() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: {a: '0.0.0'},
+        dependencies: { a: '0.0.0' },
       },
       depth: 2,
     },
@@ -1361,12 +1361,12 @@ async function testGetDownstreams() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'},
+        dependencies: { b: '0.0.0' },
       },
       depth: 1,
     },
   ];
-  const downstreams = getDownstreams({deps, dep: deps[0]});
+  const downstreams = getDownstreams({ deps, dep: deps[0] });
   assert.deepEqual(downstreams, deps.slice(1));
 }
 
@@ -1385,7 +1385,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'b',
         version: '0.0.0',
-        dependencies: {a: 'workspace:*'},
+        dependencies: { a: 'workspace:*' },
       },
       depth: 3,
     },
@@ -1394,7 +1394,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'c',
         version: '0.0.0',
-        dependencies: {b: '0.0.0'},
+        dependencies: { b: '0.0.0' },
       },
       depth: 2,
     },
@@ -1403,7 +1403,7 @@ async function testGetDownstreamsExclude() {
       meta: {
         name: 'd',
         version: '0.0.0',
-        dependencies: {a: '0.0.0'},
+        dependencies: { a: '0.0.0' },
       },
       depth: 2,
     },
@@ -1449,7 +1449,7 @@ async function testGetLocalDependencies() {
 
 async function testGetManifest() {
   assert.deepEqual(
-    await getManifest({root: `${__dirname}/fixtures/get-all-project-paths`}),
+    await getManifest({ root: `${__dirname}/fixtures/get-all-project-paths` }),
     {
       projects: ['path/to/a', 'path/to/b'],
       workspace: 'host',
@@ -1460,7 +1460,7 @@ async function testGetManifest() {
 
 async function testGetRootDir() {
   const dir = `${__dirname}/fixtures/get-root-dir/a`;
-  const result = getRootDir({dir});
+  const result = getRootDir({ dir });
   assert(result);
 }
 
@@ -1482,14 +1482,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByTwo, [
     [
-      {type: 'bazel', dir: 'a', action: 'test', args: []},
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'test', args: [] },
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
     ],
     [
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
-      {type: 'bazel', dir: 'c', action: 'test', args: []},
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'c', action: 'test', args: [] },
     ],
   ]);
 
@@ -1507,15 +1507,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(bazelByFour, [
     [
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
     ],
-    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
     [
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
     ],
-    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
   ]);
 
   const bazelByEight = await getTestGroups({
@@ -1531,12 +1531,12 @@ async function testGetTestGroups() {
     nodes: 8,
   });
   assert.deepEqual(bazelByEight, [
-    [{type: 'bazel', dir: 'a', action: 'flow', args: []}],
-    [{type: 'bazel', dir: 'a', action: 'lint', args: []}],
-    [{type: 'bazel', dir: 'a', action: 'test', args: []}],
-    [{type: 'bazel', dir: 'b', action: 'lint', args: []}],
-    [{type: 'bazel', dir: 'b', action: 'test', args: []}],
-    [{type: 'bazel', dir: 'c', action: 'test', args: []}],
+    [{ type: 'bazel', dir: 'a', action: 'flow', args: [] }],
+    [{ type: 'bazel', dir: 'a', action: 'lint', args: [] }],
+    [{ type: 'bazel', dir: 'a', action: 'test', args: [] }],
+    [{ type: 'bazel', dir: 'b', action: 'lint', args: [] }],
+    [{ type: 'bazel', dir: 'b', action: 'test', args: [] }],
+    [{ type: 'bazel', dir: 'c', action: 'test', args: [] }],
   ]);
 
   const dirByTwo = await getTestGroups({
@@ -1546,14 +1546,14 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByTwo, [
     [
-      {type: 'dir', dir: 'a', action: 'test', args: []},
-      {type: 'dir', dir: 'a', action: 'lint', args: []},
-      {type: 'dir', dir: 'a', action: 'flow', args: []},
+      { type: 'dir', dir: 'a', action: 'test', args: [] },
+      { type: 'dir', dir: 'a', action: 'lint', args: [] },
+      { type: 'dir', dir: 'a', action: 'flow', args: [] },
     ],
     [
-      {type: 'dir', dir: 'b', action: 'test', args: []},
-      {type: 'dir', dir: 'b', action: 'lint', args: []},
-      {type: 'dir', dir: 'c', action: 'test', args: []},
+      { type: 'dir', dir: 'b', action: 'test', args: [] },
+      { type: 'dir', dir: 'b', action: 'lint', args: [] },
+      { type: 'dir', dir: 'c', action: 'test', args: [] },
     ],
   ]);
 
@@ -1564,15 +1564,15 @@ async function testGetTestGroups() {
   });
   assert.deepEqual(dirByFour, [
     [
-      {type: 'dir', dir: 'a', action: 'lint', args: []},
-      {type: 'dir', dir: 'a', action: 'flow', args: []},
+      { type: 'dir', dir: 'a', action: 'lint', args: [] },
+      { type: 'dir', dir: 'a', action: 'flow', args: [] },
     ],
-    [{type: 'dir', dir: 'a', action: 'test', args: []}],
+    [{ type: 'dir', dir: 'a', action: 'test', args: [] }],
     [
-      {type: 'dir', dir: 'b', action: 'test', args: []},
-      {type: 'dir', dir: 'b', action: 'lint', args: []},
+      { type: 'dir', dir: 'b', action: 'test', args: [] },
+      { type: 'dir', dir: 'b', action: 'lint', args: [] },
     ],
-    [{type: 'dir', dir: 'c', action: 'test', args: []}],
+    [{ type: 'dir', dir: 'c', action: 'test', args: [] }],
   ]);
 }
 
@@ -1585,131 +1585,131 @@ async function testGroupByDepsets() {
   const bMeta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   const cMeta = JSON.parse(await read(`${root}/c/package.json`, 'utf8'));
   const metas = [
-    {dir: `${root}/a`, depth: 0, meta: aMeta},
-    {dir: `${root}/b`, depth: 0, meta: bMeta},
-    {dir: `${root}/c`, depth: 0, meta: cMeta},
+    { dir: `${root}/a`, depth: 0, meta: aMeta },
+    { dir: `${root}/b`, depth: 0, meta: bMeta },
+    { dir: `${root}/c`, depth: 0, meta: cMeta },
   ];
   const group = [
-    {type: 'bazel', dir: 'a', action: 'test', args: []},
-    {type: 'bazel', dir: 'a', action: 'lint', args: []},
-    {type: 'bazel', dir: 'a', action: 'flow', args: []},
-    {type: 'bazel', dir: 'b', action: 'test', args: []},
-    {type: 'bazel', dir: 'b', action: 'lint', args: []},
-    {type: 'bazel', dir: 'b', action: 'flow', args: []},
-    {type: 'bazel', dir: 'c', action: 'test', args: []},
-    {type: 'bazel', dir: 'c', action: 'lint', args: []},
-    {type: 'bazel', dir: 'c', action: 'flow', args: []},
+    { type: 'bazel', dir: 'a', action: 'test', args: [] },
+    { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+    { type: 'bazel', dir: 'b', action: 'test', args: [] },
+    { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'b', action: 'flow', args: [] },
+    { type: 'bazel', dir: 'c', action: 'test', args: [] },
+    { type: 'bazel', dir: 'c', action: 'lint', args: [] },
+    { type: 'bazel', dir: 'c', action: 'flow', args: [] },
   ];
-  assert.deepEqual(groupByDepsets({root, metas, group}), [
+  assert.deepEqual(groupByDepsets({ root, metas, group }), [
     [
-      {type: 'bazel', dir: 'a', action: 'test', args: []},
-      {type: 'bazel', dir: 'a', action: 'lint', args: []},
-      {type: 'bazel', dir: 'a', action: 'flow', args: []},
-      {type: 'bazel', dir: 'b', action: 'test', args: []},
-      {type: 'bazel', dir: 'b', action: 'lint', args: []},
-      {type: 'bazel', dir: 'b', action: 'flow', args: []},
+      { type: 'bazel', dir: 'a', action: 'test', args: [] },
+      { type: 'bazel', dir: 'a', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'a', action: 'flow', args: [] },
+      { type: 'bazel', dir: 'b', action: 'test', args: [] },
+      { type: 'bazel', dir: 'b', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'b', action: 'flow', args: [] },
     ],
     [
-      {type: 'bazel', dir: 'c', action: 'test', args: []},
-      {type: 'bazel', dir: 'c', action: 'lint', args: []},
-      {type: 'bazel', dir: 'c', action: 'flow', args: []},
+      { type: 'bazel', dir: 'c', action: 'test', args: [] },
+      { type: 'bazel', dir: 'c', action: 'lint', args: [] },
+      { type: 'bazel', dir: 'c', action: 'flow', args: [] },
     ],
   ]);
 }
 
 async function testIsYarnResolution() {
   const exact = isYarnResolution({
-    meta: {resolutions: {a: '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { a: '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(exact, true);
 
   const namespaced = isYarnResolution({
-    meta: {resolutions: {'@a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b': '0.0.0' }, name: '', version: '' },
     name: '@a/b',
   });
   assert.equal(namespaced, true);
 
   const globbed = isYarnResolution({
-    meta: {resolutions: {'**/a': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '**/a': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(globbed, true);
 
   const globbedNs = isYarnResolution({
-    meta: {resolutions: {'**/@a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '**/@a/b': '0.0.0' }, name: '', version: '' },
     name: '@a/b',
   });
   assert.equal(globbedNs, true);
 
   const direct = isYarnResolution({
-    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
     name: 'b',
   });
   assert.equal(direct, true);
 
   const directNs = isYarnResolution({
-    meta: {resolutions: {'a/@b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/@b/c': '0.0.0' }, name: '', version: '' },
     name: '@b/c',
   });
   assert.equal(directNs, true);
 
   const directOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(directOfNs, true);
 
   const directNsOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/@c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/@c/d': '0.0.0' }, name: '', version: '' },
     name: '@c/d',
   });
   assert.equal(directNsOfNs, true);
 
   const transitive = isYarnResolution({
-    meta: {resolutions: {'a/**/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/**/b': '0.0.0' }, name: '', version: '' },
     name: 'b',
   });
   assert.equal(transitive, true);
 
   const transitiveNs = isYarnResolution({
-    meta: {resolutions: {'a/**/@b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/**/@b/c': '0.0.0' }, name: '', version: '' },
     name: '@b/c',
   });
   assert.equal(transitiveNs, true);
 
   const transitiveOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/**/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/**/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(transitiveOfNs, true);
 
   const transitiveNsOfNs = isYarnResolution({
-    meta: {resolutions: {'@a/b/**/@c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/b/**/@c/d': '0.0.0' }, name: '', version: '' },
     name: '@c/d',
   });
   assert.equal(transitiveNsOfNs, true);
 
   const nested = isYarnResolution({
-    meta: {resolutions: {'a/b/c': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b/c': '0.0.0' }, name: '', version: '' },
     name: 'c',
   });
   assert.equal(nested, true);
 
   const nestedOfNs = isYarnResolution({
-    meta: {resolutions: {'a/@b/c/d': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/@b/c/d': '0.0.0' }, name: '', version: '' },
     name: 'd',
   });
   assert.equal(nestedOfNs, true);
 
   const positional = isYarnResolution({
-    meta: {resolutions: {'a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { 'a/b': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(positional, false);
 
   const positionalNs = isYarnResolution({
-    meta: {resolutions: {'@a/a/b': '0.0.0'}, name: '', version: ''},
+    meta: { resolutions: { '@a/a/b': '0.0.0' }, name: '', version: '' },
     name: 'a',
   });
   assert.equal(positionalNs, false);
@@ -1785,13 +1785,13 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutLockstep, {
     valid: false,
-    policy: {lockstep: false, exceptions: ['no-bugs', '@uber/mismatched']},
+    policy: { lockstep: false, exceptions: ['no-bugs', '@uber/mismatched'] },
     reported: {
       'no-bugs': {
         '^1.0.0': ['@uber/a', '@uber/b'],
         'npm:function-bind': ['@uber/c'],
       },
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1805,9 +1805,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withoutPartialLockstep, {
     valid: false,
-    policy: {lockstep: false, exceptions: ['@uber/mismatched']},
+    policy: { lockstep: false, exceptions: ['@uber/mismatched'] },
     reported: {
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1821,9 +1821,9 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withLockstep, {
     valid: false,
-    policy: {lockstep: true, exceptions: ['no-bugs']},
+    policy: { lockstep: true, exceptions: ['no-bugs'] },
     reported: {
-      '@uber/mismatched': {'^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a']},
+      '@uber/mismatched': { '^2.0.0': ['@uber/b'], '^1.0.0': ['@uber/a'] },
     },
   });
 
@@ -1837,7 +1837,7 @@ async function testReportMismatchedTopLevelDeps() {
   });
   assert.deepEqual(withAllExceptions, {
     valid: true,
-    policy: {lockstep: true, exceptions: ['no-bugs', '@uber/mismatched']},
+    policy: { lockstep: true, exceptions: ['no-bugs', '@uber/mismatched'] },
     reported: {},
   });
 
@@ -1846,16 +1846,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
   });
   assert.deepEqual(withVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
-    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
+    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
   });
 
   const withAllVersionedExceptions = await reportMismatchedTopLevelDeps({
@@ -1863,14 +1863,14 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
     },
   });
   assert.deepEqual(withAllVersionedExceptions, {
     valid: true,
     policy: {
       lockstep: false,
-      exceptions: [{name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']}],
+      exceptions: [{ name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] }],
     },
     reported: {},
   });
@@ -1880,16 +1880,16 @@ async function testReportMismatchedTopLevelDeps() {
     dirs: [`${root}/packages/a`, `${root}/packages/b`, `${root}/packages/c`],
     versionPolicy: {
       lockstep: true,
-      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
   });
   assert.deepEqual(withLockstepVersionedExceptions, {
     valid: false,
     policy: {
       lockstep: true,
-      exceptions: ['no-bugs', {name: '@uber/mismatched', versions: ['^1.0.0']}],
+      exceptions: ['no-bugs', { name: '@uber/mismatched', versions: ['^1.0.0'] }],
     },
-    reported: {'@uber/mismatched': {'^2.0.0': ['@uber/b']}},
+    reported: { '@uber/mismatched': { '^2.0.0': ['@uber/b'] } },
   });
 
   const withLockstepAllVersionedExceptions = await reportMismatchedTopLevelDeps(
@@ -1900,7 +1900,7 @@ async function testReportMismatchedTopLevelDeps() {
         lockstep: true,
         exceptions: [
           'no-bugs',
-          {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
+          { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
         ],
       },
     }
@@ -1911,7 +1911,7 @@ async function testReportMismatchedTopLevelDeps() {
       lockstep: true,
       exceptions: [
         'no-bugs',
-        {name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0']},
+        { name: '@uber/mismatched', versions: ['^1.0.0', '^2.0.0'] },
       ],
     },
     reported: {},
@@ -2021,7 +2021,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(!shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -2029,7 +2029,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -2037,7 +2037,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -2045,33 +2045,7 @@ async function testVersionOnboarding() {
       exceptions: ['foo'],
     };
     const name = 'bar';
-    assert(!shouldSync({versionPolicy, name}));
-  }
-  {
-    const versionPolicy = {
-      lockstep: true,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
-  }
-  {
-    const versionPolicy = {
-      lockstep: false,
-      exceptions: [
-        {
-          name: 'foo',
-          versions: ['^1.0.0'],
-        },
-      ],
-    };
-    const name = 'foo';
-    assert(shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -2083,8 +2057,34 @@ async function testVersionOnboarding() {
         },
       ],
     };
+    const name = 'foo';
+    assert(shouldSync({ versionPolicy, name }));
+  }
+  {
+    const versionPolicy = {
+      lockstep: false,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
+    const name = 'foo';
+    assert(shouldSync({ versionPolicy, name }));
+  }
+  {
+    const versionPolicy = {
+      lockstep: true,
+      exceptions: [
+        {
+          name: 'foo',
+          versions: ['^1.0.0'],
+        },
+      ],
+    };
     const name = 'bar';
-    assert(shouldSync({versionPolicy, name}));
+    assert(shouldSync({ versionPolicy, name }));
   }
   {
     const versionPolicy = {
@@ -2097,7 +2097,7 @@ async function testVersionOnboarding() {
       ],
     };
     const name = 'bar';
-    assert(!shouldSync({versionPolicy, name}));
+    assert(!shouldSync({ versionPolicy, name }));
   }
   {
     const name = 'foo';
@@ -2114,7 +2114,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^1.0.0');
+    assert.equal(getVersion({ name, deps }), '^1.0.0');
   }
   {
     const name = 'foo';
@@ -2153,7 +2153,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^2.0.0');
+    assert.equal(getVersion({ name, deps }), '^2.0.0');
   }
   {
     const name = 'foo';
@@ -2181,7 +2181,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '~1.0.0');
+    assert.equal(getVersion({ name, deps }), '~1.0.0');
   }
   {
     const name = 'foo';
@@ -2220,7 +2220,7 @@ async function testVersionOnboarding() {
         depth: 0,
       },
     ];
-    assert.equal(getVersion({name, deps}), '^2.0.0'); // do not use 'resolutions' version
+    assert.equal(getVersion({ name, deps }), '^2.0.0'); // do not use 'resolutions' version
   }
 }
 
@@ -2238,7 +2238,7 @@ async function testYarnCommands() {
   ];
   const root = `${tmp}/tmp/yarn-commands`;
 
-  await install({root, cwd: `${root}/a`});
+  await install({ root, cwd: `${root}/a` });
 
   // build
   const buildStreamFile = `${tmp}/tmp/yarn-commands/build-stream.txt`;
@@ -2328,7 +2328,7 @@ async function testCommand() {
   const streamFile = `${tmp}/tmp/bin/stream.txt`;
   const stream = createWriteStream(streamFile);
   await new Promise(resolve => stream.on('open', resolve));
-  await exec(`${jazelle}`, {cwd}, [stream, stream]);
+  await exec(`${jazelle}`, { cwd }, [stream, stream]);
   assert((await read(streamFile, 'utf8')).includes('Usage: jazelle [command]'));
 }
 
@@ -2342,13 +2342,13 @@ async function testYarnCommand() {
   const yarnStreamFile = `${tmp}/tmp/bin/yarn-stream.txt`;
   const yarnStream = createWriteStream(yarnStreamFile);
   await new Promise(resolve => yarnStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version --cwd a`, {cwd}, [yarnStream]);
+  await exec(`${jazelle} yarn --version --cwd a`, { cwd }, [yarnStream]);
   assert((await read(yarnStreamFile, 'utf8')).includes('.'));
 
   const cwdStreamFile = `${tmp}/tmp/bin/cwd-stream.txt`;
   const cwdStream = createWriteStream(cwdStreamFile);
   await new Promise(resolve => cwdStream.on('open', resolve));
-  await exec(`${jazelle} yarn --version`, {cwd: `${cwd}/a`}, [cwdStream]);
+  await exec(`${jazelle} yarn --version`, { cwd: `${cwd}/a` }, [cwdStream]);
   assert((await read(cwdStreamFile, 'utf8')).includes('.'));
 }
 
@@ -2362,7 +2362,7 @@ async function testBazelCommand() {
   const bazelStreamFile = `${tmp}/tmp/bin/bazel-stream.txt`;
   const bazelStream = createWriteStream(bazelStreamFile);
   await new Promise(resolve => bazelStream.on('open', resolve));
-  await exec(`${jazelle} bazel version`, {cwd}, [bazelStream]);
+  await exec(`${jazelle} bazel version`, { cwd }, [bazelStream]);
   assert((await read(bazelStreamFile, 'utf8')).includes('Build label:'));
 }
 
@@ -2387,7 +2387,7 @@ async function testDevCommand() {
   const devStream = createWriteStream(devStreamFile);
   await new Promise(resolve => devStream.on('open', resolve));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
   await spawn('./test-sigint.sh', [], {
     env: {
@@ -2428,9 +2428,9 @@ async function testStartCommand() {
   const startStream = createWriteStream(startStreamFile);
   await new Promise(resolve => startStream.on('open', resolve));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
-  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
+  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
   assert((await read(startStreamFile, 'utf8')).includes('\nstart\n'));
 }
 
@@ -2460,9 +2460,9 @@ async function testBazelDependentBuilds() {
   assert((await read(b)).includes('module.exports = 111'));
   assert((await read(a)).includes('require(\\"b\\") + require(\\"c\\")'));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
-  await exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream]);
+  await exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream]);
   assert.equal(await read(startStreamFile, 'utf8'), '333\n');
   assert(await exists(`${cwd}/a/foo/foo.js`));
   assert(await exists(`${cwd}/b/compiled/foo.js`));
@@ -2491,11 +2491,11 @@ async function testBazelDependentFailure() {
   const c = `${cwd}/c/package.json`;
   assert((await read(c, 'utf8')).includes('mkdir -p dist && mkdir dist'));
 
-  await install({root: cwd, cwd: `${cwd}/a`});
+  await install({ root: cwd, cwd: `${cwd}/a` });
 
   // $FlowFixMe `assert` typedef is missing `rejects` method
   await assert.rejects(
-    exec(`${jazelle} start`, {cwd: `${cwd}/a`}, [startStream, startStream])
+    exec(`${jazelle} start`, { cwd: `${cwd}/a` }, [startStream, startStream])
   );
 }
 
@@ -2558,7 +2558,7 @@ async function testLocalize() {
   await exec(cmd);
 
   const root = `${tmp}/tmp/localize`;
-  await localize({root});
+  await localize({ root });
   const meta = JSON.parse(await read(`${root}/b/package.json`, 'utf8'));
   assert.equal(meta.dependencies.a, '0.0.0-monorepo');
   assert.equal(meta.devDependencies.a, '0.0.0-monorepo');
@@ -2591,7 +2591,7 @@ async function testCheck() {
   );
 
   // Check with --all
-  result = await check({root, json: true, all: true});
+  result = await check({ root, json: true, all: true });
   if (!result) {
     assert.ok(result);
     return;
@@ -2624,7 +2624,7 @@ async function testOutdated() {
   const root = `${tmp}/tmp/outdated`;
 
   // Sanity check
-  await outdated({root, logger});
+  await outdated({ root, logger });
 
   // helper function to sort an array of objects by their
   // 'packageName' property.
@@ -2648,7 +2648,7 @@ async function testOutdated() {
   flush();
 
   // Test --dedup option
-  await outdated({root, logger, dedup: true});
+  await outdated({ root, logger, dedup: true });
   data.sort();
   assert.equal(data[0], 'only-version-one-zero-zero 0.1.0 0.2.0 1.0.0');
   assert.equal(data[1].substring(0, 'semver ^6.2.0 '.length), 'semver ^6.2.0 ');
@@ -2660,7 +2660,7 @@ async function testOutdated() {
 
   // Test --json option w/out --dedup
   {
-    await outdated({root, logger, json: true, dedup: false});
+    await outdated({ root, logger, json: true, dedup: false });
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
       parsed = JSON.parse(data.join(''));
@@ -2705,7 +2705,7 @@ async function testOutdated() {
 
   // Test --json option w/ --dedup
   {
-    await outdated({root, logger, json: true, dedup: true});
+    await outdated({ root, logger, json: true, dedup: true });
 
     let parsed /*: Array<{[string]: string}> */ = [];
     try {
@@ -2752,9 +2752,9 @@ async function testShouldInstall() {
   const root = `${tmp}/tmp/should-install`;
 
   // should bypass yarn install due to bool_shouldinstall
-  await install({root, cwd: root});
+  await install({ root, cwd: root });
   assert.equal(await read(`${root}/yarn.lock`), '');
 
-  await focus({root, cwd: root, packages: ['a']});
+  await focus({ root, cwd: root, packages: ['a'] });
   assert.equal(await read(`${root}/yarn.lock`), '');
 }

--- a/utils/types-manager.js
+++ b/utils/types-manager.js
@@ -1,6 +1,6 @@
 // @flow
-const { maxSatisfying, rsort } = require('../vendor/semver/semver.js');
-const { exec } = require('./node-helpers.js');
+const {maxSatisfying, rsort} = require('../vendor/semver/semver.js');
+const {exec} = require('./node-helpers.js');
 
 /*::
 type ExternalDep = {name: string, range?: string};
@@ -34,7 +34,7 @@ const checkBundledTypes /*: CheckBundledTypes */ = async (
   try {
     const versionSpec = versionRange || 'latest';
     const cmd = `npm view ${packageName}@${versionSpec} --json`;
-    const result = await exec(cmd, { cwd: root, maxBuffer: MAX_BUFFER_SIZE });
+    const result = await exec(cmd, {cwd: root, maxBuffer: MAX_BUFFER_SIZE});
     const data = JSON.parse(result.trim());
     return !!(data.types || data.typings);
   } catch (error) {
@@ -53,7 +53,7 @@ const findBestTypesVersion /*: FindBestTypesVersion */ = async (
 ) => {
   try {
     const cmd = `npm view ${typesPackageName} versions --json`;
-    const result = await exec(cmd, { cwd: root, maxBuffer: MAX_BUFFER_SIZE });
+    const result = await exec(cmd, {cwd: root, maxBuffer: MAX_BUFFER_SIZE});
     const data = JSON.parse(result.trim());
     const versions = data || [];
 
@@ -109,7 +109,7 @@ const getTypesPackages /*: GetTypesPackages */ = async (
 ) => {
   const typesDeps = [];
 
-  for (const { name, range } of externals) {
+  for (const {name, range} of externals) {
     // Skip if already a @types package
     if (name.startsWith('@types/')) continue;
 
@@ -153,7 +153,7 @@ const removeTypesPackage /*: RemoveTypesPackage */ = async (
   packageName,
   roots
 ) => {
-  const { read, write } = require('./node-helpers.js');
+  const {read, write} = require('./node-helpers.js');
   // Convert scoped packages: @babel/core → @types/babel__core
   const typesPackageName = packageName.startsWith('@')
     ? `@types/${packageName.slice(1).replace('/', '__')}`

--- a/utils/types-manager.js
+++ b/utils/types-manager.js
@@ -1,7 +1,6 @@
 // @flow
-const {maxSatisfying, rsort} = require('../vendor/semver/semver.js');
-const {exec} = require('./node-helpers.js');
-const {node, yarn} = require('./binary-paths.js');
+const { maxSatisfying, rsort } = require('../vendor/semver/semver.js');
+const { exec } = require('./node-helpers.js');
 
 /*::
 type ExternalDep = {name: string, range?: string};
@@ -34,8 +33,8 @@ const checkBundledTypes /*: CheckBundledTypes */ = async (
 ) => {
   try {
     const versionSpec = versionRange || 'latest';
-    const cmd = `${node} ${yarn} info ${packageName}@${versionSpec} --json`;
-    const result = await exec(cmd, {cwd: root, maxBuffer: MAX_BUFFER_SIZE});
+    const cmd = `npm view ${packageName}@${versionSpec} --json`;
+    const result = await exec(cmd, { cwd: root, maxBuffer: MAX_BUFFER_SIZE });
     const data = JSON.parse(result.trim());
     return !!(data.types || data.typings);
   } catch (error) {
@@ -53,11 +52,10 @@ const findBestTypesVersion /*: FindBestTypesVersion */ = async (
   promptForTypesVersion
 ) => {
   try {
-    // Get all versions
-    const cmd = `${node} ${yarn} info ${typesPackageName} versions --json`;
-    const result = await exec(cmd, {cwd: root, maxBuffer: MAX_BUFFER_SIZE});
+    const cmd = `npm view ${typesPackageName} versions --json`;
+    const result = await exec(cmd, { cwd: root, maxBuffer: MAX_BUFFER_SIZE });
     const data = JSON.parse(result.trim());
-    const versions = data.versions || data || [];
+    const versions = data || [];
 
     if (versions.length === 0) {
       console.warn(`No versions found for ${typesPackageName}`);
@@ -111,7 +109,7 @@ const getTypesPackages /*: GetTypesPackages */ = async (
 ) => {
   const typesDeps = [];
 
-  for (const {name, range} of externals) {
+  for (const { name, range } of externals) {
     // Skip if already a @types package
     if (name.startsWith('@types/')) continue;
 
@@ -155,7 +153,7 @@ const removeTypesPackage /*: RemoveTypesPackage */ = async (
   packageName,
   roots
 ) => {
-  const {read, write} = require('./node-helpers.js');
+  const { read, write } = require('./node-helpers.js');
   // Convert scoped packages: @babel/core → @types/babel__core
   const typesPackageName = packageName.startsWith('@')
     ? `@types/${packageName.slice(1).replace('/', '__')}`

--- a/utils/upgrade-prompts.js
+++ b/utils/upgrade-prompts.js
@@ -1,6 +1,6 @@
 // @flow
 const prompts = require('../vendor/prompts');
-const { rsort } = require('../vendor/semver');
+const {rsort} = require('../vendor/semver');
 
 /*::
 type PromptForTypesVersion = (
@@ -12,14 +12,14 @@ type PromptForTypesVersion = (
 */
 
 const createPromptChoices = latest => [
-  { title: `Use latest version (${latest})`, value: 'latest' },
-  { title: 'Enter a specific version manually', value: 'manual' },
-  { title: 'Skip this package', value: 'skip' },
-  { title: 'Abort the upgrade process', value: 'abort' },
+  {title: `Use latest version (${latest})`, value: 'latest'},
+  {title: 'Enter a specific version manually', value: 'manual'},
+  {title: 'Skip this package', value: 'skip'},
+  {title: 'Abort the upgrade process', value: 'abort'},
 ];
 
 const promptForManualVersion = async versions => {
-  const { manualVersion } = await prompts({
+  const {manualVersion} = await prompts({
     type: 'text',
     name: 'manualVersion',
     message: 'Enter the specific version:',
@@ -63,7 +63,8 @@ const promptForTypesVersion /*: PromptForTypesVersion */ = async (
   const recentVersions = sortedVersions.slice(0, 10); // Show top 10 versions
 
   console.log(
-    `\nNo compatible @types version found for ${typesPackageName} with range "${originalRange || 'unspecified'
+    `\nNo compatible @types version found for ${typesPackageName} with range "${
+      originalRange || 'unspecified'
     }"`
   );
   console.log(`Available versions: ${recentVersions.join(', ')}`);
@@ -76,7 +77,7 @@ const promptForTypesVersion /*: PromptForTypesVersion */ = async (
 
   const choices = createPromptChoices(latest);
 
-  const { action } = await prompts({
+  const {action} = await prompts({
     type: 'select',
     name: 'action',
     message: `What would you like to do for ${typesPackageName}?`,

--- a/utils/upgrade-prompts.js
+++ b/utils/upgrade-prompts.js
@@ -1,6 +1,6 @@
 // @flow
-const prompts = require('prompts');
-const {rsort} = require('semver');
+const prompts = require('../vendor/prompts');
+const { rsort } = require('../vendor/semver');
 
 /*::
 type PromptForTypesVersion = (
@@ -12,14 +12,14 @@ type PromptForTypesVersion = (
 */
 
 const createPromptChoices = latest => [
-  {title: `Use latest version (${latest})`, value: 'latest'},
-  {title: 'Enter a specific version manually', value: 'manual'},
-  {title: 'Skip this package', value: 'skip'},
-  {title: 'Abort the upgrade process', value: 'abort'},
+  { title: `Use latest version (${latest})`, value: 'latest' },
+  { title: 'Enter a specific version manually', value: 'manual' },
+  { title: 'Skip this package', value: 'skip' },
+  { title: 'Abort the upgrade process', value: 'abort' },
 ];
 
 const promptForManualVersion = async versions => {
-  const {manualVersion} = await prompts({
+  const { manualVersion } = await prompts({
     type: 'text',
     name: 'manualVersion',
     message: 'Enter the specific version:',
@@ -63,8 +63,7 @@ const promptForTypesVersion /*: PromptForTypesVersion */ = async (
   const recentVersions = sortedVersions.slice(0, 10); // Show top 10 versions
 
   console.log(
-    `\nNo compatible @types version found for ${typesPackageName} with range "${
-      originalRange || 'unspecified'
+    `\nNo compatible @types version found for ${typesPackageName} with range "${originalRange || 'unspecified'
     }"`
   );
   console.log(`Available versions: ${recentVersions.join(', ')}`);
@@ -77,7 +76,7 @@ const promptForTypesVersion /*: PromptForTypesVersion */ = async (
 
   const choices = createPromptChoices(latest);
 
-  const {action} = await prompts({
+  const { action } = await prompts({
     type: 'select',
     name: 'action',
     message: `What would you like to do for ${typesPackageName}?`,

--- a/vendor/prompts/dist/elements/autocomplete.js
+++ b/vendor/prompts/dist/elements/autocomplete.js
@@ -4,11 +4,11 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       erase = _require.erase,
       cursor = _require.cursor;
 

--- a/vendor/prompts/dist/elements/autocompleteMultiselect.js
+++ b/vendor/prompts/dist/elements/autocompleteMultiselect.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       cursor = _require.cursor;
 
 const MultiselectPrompt = require('./multiselect');

--- a/vendor/prompts/dist/elements/confirm.js
+++ b/vendor/prompts/dist/elements/confirm.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
@@ -8,7 +8,7 @@ const _require = require('../util'),
       style = _require.style,
       clear = _require.clear;
 
-const _require2 = require('sisteransi'),
+const _require2 = require('../../../sisteransi'),
       erase = _require2.erase,
       cursor = _require2.cursor;
 /**

--- a/vendor/prompts/dist/elements/date.js
+++ b/vendor/prompts/dist/elements/date.js
@@ -4,7 +4,7 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
@@ -13,7 +13,7 @@ const _require = require('../util'),
       clear = _require.clear,
       figures = _require.figures;
 
-const _require2 = require('sisteransi'),
+const _require2 = require('../../../sisteransi'),
       erase = _require2.erase,
       cursor = _require2.cursor;
 

--- a/vendor/prompts/dist/elements/multiselect.js
+++ b/vendor/prompts/dist/elements/multiselect.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       cursor = _require.cursor;
 
 const Prompt = require('./prompt');

--- a/vendor/prompts/dist/elements/number.js
+++ b/vendor/prompts/dist/elements/number.js
@@ -4,11 +4,11 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       cursor = _require.cursor,
       erase = _require.erase;
 

--- a/vendor/prompts/dist/elements/prompt.js
+++ b/vendor/prompts/dist/elements/prompt.js
@@ -7,11 +7,11 @@ const _require = require('../util'),
 
 const EventEmitter = require('events');
 
-const _require2 = require('sisteransi'),
+const _require2 = require('../../../sisteransi'),
       beep = _require2.beep,
       cursor = _require2.cursor;
 
-const color = require('kleur');
+const color = require('../../../kleur');
 /**
  * Base prompt skeleton
  * @param {Stream} [opts.stdin] The Readable stream to listen to

--- a/vendor/prompts/dist/elements/select.js
+++ b/vendor/prompts/dist/elements/select.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
@@ -11,7 +11,7 @@ const _require = require('../util'),
       wrap = _require.wrap,
       entriesToDisplay = _require.entriesToDisplay;
 
-const _require2 = require('sisteransi'),
+const _require2 = require('../../../sisteransi'),
       cursor = _require2.cursor;
 /**
  * SelectPrompt Base Element

--- a/vendor/prompts/dist/elements/text.js
+++ b/vendor/prompts/dist/elements/text.js
@@ -4,11 +4,11 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       erase = _require.erase,
       cursor = _require.cursor;
 

--- a/vendor/prompts/dist/elements/toggle.js
+++ b/vendor/prompts/dist/elements/toggle.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const color = require('kleur');
+const color = require('../../../kleur');
 
 const Prompt = require('./prompt');
 
@@ -8,7 +8,7 @@ const _require = require('../util'),
       style = _require.style,
       clear = _require.clear;
 
-const _require2 = require('sisteransi'),
+const _require2 = require('../../../sisteransi'),
       cursor = _require2.cursor,
       erase = _require2.erase;
 /**

--- a/vendor/prompts/dist/util/clear.js
+++ b/vendor/prompts/dist/util/clear.js
@@ -8,7 +8,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 
 const strip = require('./strip');
 
-const _require = require('sisteransi'),
+const _require = require('../../../sisteransi'),
       erase = _require.erase,
       cursor = _require.cursor;
 

--- a/vendor/prompts/dist/util/style.js
+++ b/vendor/prompts/dist/util/style.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const c = require('kleur');
+const c = require('../../../kleur');
 
 const figures = require('./figures'); // rendering user input.
 

--- a/vendor/prompts/lib/elements/autocomplete.js
+++ b/vendor/prompts/lib/elements/autocomplete.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
-const { erase, cursor } = require('sisteransi');
+const { erase, cursor } = require('../../../sisteransi');
 const { style, clear, figures, wrap, entriesToDisplay } = require('../util');
 
 const getVal = (arr, i) => arr[i] && (arr[i].value || arr[i].title || arr[i]);

--- a/vendor/prompts/lib/elements/autocompleteMultiselect.js
+++ b/vendor/prompts/lib/elements/autocompleteMultiselect.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const color = require('kleur');
-const { cursor } = require('sisteransi');
+const color = require('../../../kleur');
+const { cursor } = require('../../../sisteransi');
 const MultiselectPrompt = require('./multiselect');
 const { clear, style, figures } = require('../util');
 /**

--- a/vendor/prompts/lib/elements/confirm.js
+++ b/vendor/prompts/lib/elements/confirm.js
@@ -1,7 +1,7 @@
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
 const { style, clear } = require('../util');
-const { erase, cursor } = require('sisteransi');
+const { erase, cursor } = require('../../../sisteransi');
 
 /**
  * ConfirmPrompt Base Element

--- a/vendor/prompts/lib/elements/date.js
+++ b/vendor/prompts/lib/elements/date.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
 const { style, clear, figures } = require('../util');
-const { erase, cursor } = require('sisteransi');
+const { erase, cursor } = require('../../../sisteransi');
 const { DatePart, Meridiem, Day, Hours, Milliseconds, Minutes, Month, Seconds, Year } = require('../dateparts');
 
 const regex = /\\(.)|"((?:\\["\\]|[^"])+)"|(D[Do]?|d{3,4}|d)|(M{1,4})|(YY(?:YY)?)|([aA])|([Hh]{1,2})|(m{1,2})|(s{1,2})|(S{1,4})|./g;

--- a/vendor/prompts/lib/elements/multiselect.js
+++ b/vendor/prompts/lib/elements/multiselect.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const color = require('kleur');
-const { cursor } = require('sisteransi');
+const color = require('../../../kleur');
+const { cursor } = require('../../../sisteransi');
 const Prompt = require('./prompt');
 const { clear, figures, style, wrap, entriesToDisplay } = require('../util');
 

--- a/vendor/prompts/lib/elements/number.js
+++ b/vendor/prompts/lib/elements/number.js
@@ -1,6 +1,6 @@
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
-const { cursor, erase } = require('sisteransi');
+const { cursor, erase } = require('../../../sisteransi');
 const { style, figures, clear, lines } = require('../util');
 
 const isNumber = /[0-9]/;

--- a/vendor/prompts/lib/elements/prompt.js
+++ b/vendor/prompts/lib/elements/prompt.js
@@ -3,8 +3,8 @@
 const readline = require('readline');
 const { action } = require('../util');
 const EventEmitter = require('events');
-const { beep, cursor } = require('sisteransi');
-const color = require('kleur');
+const { beep, cursor } = require('../../../sisteransi');
+const color = require('../../../kleur');
 
 /**
  * Base prompt skeleton

--- a/vendor/prompts/lib/elements/select.js
+++ b/vendor/prompts/lib/elements/select.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
 const { style, clear, figures, wrap, entriesToDisplay } = require('../util');
-const { cursor } = require('sisteransi');
+const { cursor } = require('../../../sisteransi');
 
 /**
  * SelectPrompt Base Element

--- a/vendor/prompts/lib/elements/text.js
+++ b/vendor/prompts/lib/elements/text.js
@@ -1,6 +1,6 @@
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
-const { erase, cursor } = require('sisteransi');
+const { erase, cursor } = require('../../../sisteransi');
 const { style, clear, lines, figures } = require('../util');
 
 /**

--- a/vendor/prompts/lib/elements/toggle.js
+++ b/vendor/prompts/lib/elements/toggle.js
@@ -1,7 +1,7 @@
-const color = require('kleur');
+const color = require('../../../kleur');
 const Prompt = require('./prompt');
 const { style, clear } = require('../util');
-const { cursor, erase } = require('sisteransi');
+const { cursor, erase } = require('../../../sisteransi');
 
 /**
  * TogglePrompt Base Element

--- a/vendor/prompts/lib/util/clear.js
+++ b/vendor/prompts/lib/util/clear.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const strip = require('./strip');
-const { erase, cursor } = require('sisteransi');
+const { erase, cursor } = require('../../../sisteransi');
 
 const width = str => [...strip(str)].length;
 

--- a/vendor/prompts/lib/util/style.js
+++ b/vendor/prompts/lib/util/style.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const c = require('kleur');
+const c = require('../../../kleur');
 const figures = require('./figures');
 
 // rendering user input.


### PR DESCRIPTION
Fixes broken 0.0.0-standalone.102 version:
- Fixes paths for prompts package to go through vendor
- Switches from yarn commands to npm view because of authentication issues
- Fixes interactive: false flag to prevent prompting in non-interactive mode

