### PR TITLE
Removed deprecated `--force` option and cleans up the documentation for 'jz purge'

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,11 +466,15 @@ Upgrades a dependency across all local projects that use it
 
 ### `jazelle purge`
 
-Removes generated files (i.e. `node_modules` folders and bazel output files)
+Removes generated files and caches to give you a clean slate:
 
-`jazelle purge --force`
+- Jazelle's temporary directory
+- Repository and project-specific npm modules directories (e.g. `node_modules/`)
+- Repository Yarn PnP, cache, and state files (e.g. `.pnp.cjs`, `.yarn/cache`, `.yarn/build-state.yml`)
+- Global Yarn cache (e.g. `~/.yarn/berry/cache/`)
+- Bazel outputs and cache (e.g. `bazel clean --expunge`)
 
-- `--force` - Whether to also purge Bazel cache. Defaults to false
+`jazelle purge`
 
 ### `jazelle check`
 


### PR DESCRIPTION
There was a question around purging non-committed artifacts in a repository, for which `jz purge` can help.  Updated the documentation to remove the no-longer-used `--force` command as well as enumerating more clearly what actually gets removed.

---

See [this Slack thread](https://uber.slack.com/archives/C09UVSD6JUV/p1768598259876479) for more context.

> So this should be a problem with dependency caching right ? I have tried installing and rebuilding using jz rebuild  didn't help , will try removing the yarn cache manually and try again.