### PR TITLE
Add --skip-types flag to jz upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,10 @@ Removes a dependency from the project's package.json, syncing the `yarn.lock` fi
 
 Upgrades a dependency across all local projects that use it
 
-`jazelle upgrade [args...]`
+`jazelle upgrade [args...] [--skip-types]`
 
 - `args` - Space-separated list of dependency names and optionally their desired version ranges. e.g., `foo@^1.2.3`. If version is not specified, defaults to `npm info [name] version` for 3rd party packages, or the local version for local packages. Note that local packages must be pinned to an exact version.
+- `--skip-types` - Skip automatic `@types` package syncing. Useful for automated pipelines (e.g. minor/patch upgrades) where `@types` syncing is not required.
 
 ### `jazelle purge`
 
@@ -885,9 +886,10 @@ Removes a dependency from the project's package.json, syncing the `yarn.lock` fi
 
 Upgrades a dependency across all local projects that use it
 
-`let upgrade: ({root: string, args: Array<string>}) => Promise<void>`
+`let upgrade: ({root: string, args: Array<string>, skipTypes?: boolean}) => Promise<void>`
 
 - `args` - Space-separated list of dependency names and optionally their desired version ranges. e.g., `foo@^1.2.3`. If version is not specified, defaults to `npm info [name] version` for 3rd party packages, or the local version for local packages. Note that local packages must be pinned to an exact version.
+- `skipTypes` - Skip automatic `@types` package syncing. Defaults to `false`.
 
 ### `purge`
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -17,6 +17,7 @@ export type UpgradeArgs = {
   root: string,
   args: Array<string>,
   interactive?: boolean,
+  skipTypes?: boolean,
 };
 export type Upgrade = (UpgradeArgs) => Promise<void>;
 type ExternalDep = {name: string, range?: string};
@@ -27,7 +28,7 @@ type RemoveTypesPackage = (string, Array<string>) => Promise<void>;
 type PromptForTypesVersion = (string, ?string, Array<string>, boolean) => Promise<?string>;
 */
 
-const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
+const upgrade /*: Upgrade */ = async ({root, args, interactive = true, skipTypes = false}) => {
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 
@@ -76,7 +77,9 @@ const upgrade /*: Upgrade */ = async ({root, args, interactive = true}) => {
     const promptFn = interactive ? promptForTypesVersion : async () => null;
 
     // Add @types packages
-    const typesDeps = await getTypesPackages(externals, root, roots, promptFn);
+    const typesDeps = skipTypes
+      ? []
+      : await getTypesPackages(externals, root, roots, promptFn);
 
     await spawn(
       node,

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -28,7 +28,12 @@ type RemoveTypesPackage = (string, Array<string>) => Promise<void>;
 type PromptForTypesVersion = (string, ?string, Array<string>, boolean) => Promise<?string>;
 */
 
-const upgrade /*: Upgrade */ = async ({root, args, interactive = true, skipTypes = false}) => {
+const upgrade /*: Upgrade */ = async ({
+  root,
+  args,
+  interactive = true,
+  skipTypes = false,
+}) => {
   const {projects} = await getManifest({root});
   const roots = projects.map(dir => `${root}/${dir}`);
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,12 @@ const runCLI /*: RunCLI */ = async argv => {
 
         [args...]                     Packages to upgrade and optionally their version ranges. e.g., foo@^1.2.3 bar@^1.2.3
         --skip-types                  Skip automatic @types package syncing`,
-        async ({'skip-types': skipTypes}) => upgrade({root: await rootOf(args), args: rest.filter(a => a !== '--skip-types'), skipTypes: Boolean(skipTypes)}),
+        async ({'skip-types': skipTypes}) =>
+          upgrade({
+            root: await rootOf(args),
+            args: rest.filter(a => a !== '--skip-types'),
+            skipTypes: Boolean(skipTypes),
+          }),
       ],
       purge: [
         `Remove generated files (i.e. node_modules folders and bazel output files)`,

--- a/index.js
+++ b/index.js
@@ -176,8 +176,9 @@ const runCLI /*: RunCLI */ = async argv => {
       upgrade: [
         `Upgrade a package version across all projects
 
-        [args...]                     Packages to upgrade and optionally their version ranges. e.g., foo@^1.2.3 bar@^1.2.3`,
-        async () => upgrade({root: await rootOf(args), args: rest}),
+        [args...]                     Packages to upgrade and optionally their version ranges. e.g., foo@^1.2.3 bar@^1.2.3
+        --skip-types                  Skip automatic @types package syncing`,
+        async ({'skip-types': skipTypes}) => upgrade({root: await rootOf(args), args: rest.filter(a => a !== '--skip-types'), skipTypes: Boolean(skipTypes)}),
       ],
       purge: [
         `Remove generated files (i.e. node_modules folders and bazel output files)`,

--- a/tests/index.js
+++ b/tests/index.js
@@ -183,6 +183,7 @@ async function runTests() {
     t(testFocus),
     t(testUpgrade),
     t(testUpgradeTypes),
+    t(testUpgradeSkipTypes),
     t(testPurge),
     t(testBump),
     // t(testEach),
@@ -485,6 +486,26 @@ async function testUpgradeTypes() {
 
   // Test 5: Interactive mode behavior (mocked, fast)
   await testUpgradeTypesInteractiveMode();
+}
+
+async function testUpgradeSkipTypes() {
+  const testRoot = `${tmp}/tmp/upgrade-skip-types`;
+  await exec(`cp -r ${__dirname}/fixtures/upgrade-types/ ${testRoot}`);
+  const meta = `${testRoot}/test-app/package.json`;
+
+  await upgrade({
+    root: testRoot,
+    args: ['lodash@4.17.21'],
+    skipTypes: true,
+  });
+
+  const pkg = JSON.parse(await read(meta, 'utf8'));
+  assert(pkg.dependencies.lodash === '4.17.21', 'Should upgrade lodash');
+  assert(
+    !pkg.devDependencies['@types/lodash'] ||
+      pkg.devDependencies['@types/lodash'] === '4.14.180',
+    'Should not upgrade @types/lodash when skipTypes is true'
+  );
 }
 
 async function testUpgradeTypesVersionRanges() {


### PR DESCRIPTION
## Summary

Adds a `--skip-types` flag to the `jz upgrade` command to allow opting out of automatic `@types` package syncing.

This is needed for automated upgrade pipelines (e.g. Greenkeeper) that run non-interactively and only perform minor/patch upgrades — where the major version doesn't change, so `@types` syncing can be safely skipped.

Asked for in [WPT-17696](https://t3.uberinternal.com/browse/WPT-17696).

## Usage

```bash
jz upgrade lodash@^4.17.21 --skip-types
```