### PR TITLE
Bump to version 0.0.0-standalone.104

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jazelle",
-  "version": "0.0.0-standalone.103",
+  "version": "0.0.0-standalone.104",
   "main": "index.js",
   "bin": {
     "barn": "bin/bootstrap.sh",


### PR DESCRIPTION
Bump version following the --skip-types flag addition (#179).